### PR TITLE
feat: add scratch pane for instant lma toggle

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,30 @@
+# Lemonaid Development Guidelines
+
+## Before Committing
+
+1. **Bump the version** in `pyproject.toml` if adding features or fixes
+2. **Update CHANGES.md** with a brief description of what changed
+3. **Update docs/** if the change affects user-facing behavior
+4. **Update README.md** if adding significant features (add to Features list)
+
+## Version Scheme
+
+- Patch (0.1.x → 0.1.y): Bug fixes, minor tweaks
+- Minor (0.1.x → 0.2.0): New features, significant changes
+- Major (0.x → 1.0): Breaking changes, major milestones
+
+## Project Structure
+
+- `src/lemonaid/` - Main package
+- `docs/` - User documentation (tmux.md, wezterm.md, etc.)
+- `CHANGES.md` - Changelog (update with every release)
+
+## Testing
+
+```bash
+uv run pytest
+```
+
+## Code Style
+
+Handled by pre-commit hooks (ruff). Just commit and it'll auto-format.

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ uv.lock
 
 # lemons
 .claude/**
+!.claude/CLAUDE.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 0.2.0 (2026-01-23)
+
+### Added
+
+- **Scratch pane**: Toggle a persistent `lma` pane with `lemonaid tmux scratch`. The pane stays running in the background for instant show/hide without startup delay. Auto-dismisses after selecting a notification.
+- `lma --scratch` flag for running in scratch mode (auto-hide after selection)
+
+## 0.1.1
+
+### Added
+
+- `tui.transparent` config option for terminal transparency support
+- Notification names derived from tmux session name automatically
+
+### Fixed
+
+- Various tmux color improvements
+
+## 0.1.0
+
+Initial release with core features:
+
+- **Inbox TUI** (`lma`): View and manage notifications from Claude Code and other tools
+- **Notification system**: Receive notifications via `lemonaid claude notify` hook
+- **tmux integration**: Switch to notification source, back-navigation, session templates
+- **WezTerm integration**: Alternative to tmux with similar features
+- **Window status**: Colorized tmux window titles based on directory/process
+- **Claude Code patcher**: Reduce notification delay from 10s to 100ms
+- **Mark as read**: `prefix + m` keybinding for tmux
+- **Unread indicators**: Visual distinction for unread notifications
+- **Session templates**: Create tmux sessions with predefined window layouts

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Eventually other tools will get packaged here as well.
 
 - **Notification inbox**: Track which Claude Code sessions need your attention
 - **Terminal integration**: Hit enter to jump directly to the waiting session's pane (supports [tmux](docs/tmux.md) and [WezTerm](docs/wezterm.md))
+- **Scratch pane** (tmux): Toggle an always-on inbox with a keybinding - no startup delay, auto-hides after selection
 - **Back navigation**: Toggle between your inbox and the session you jumped to
 - **Auto-refresh TUI**: See new notifications appear without losing your place
 - **Upsert behavior**: Repeated notifications update timestamp instead of creating duplicates

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -60,7 +60,52 @@ Because the swap is atomic, pressing `prefix + p` repeatedly toggles between two
 
 - `lemonaid tmux back` - Switch to the saved back location
 - `lemonaid tmux swap <session> <pane_id>` - Swap back location and print target (for keybinding integration)
+- `lemonaid tmux scratch` - Toggle the scratch lma pane (see below)
 - `lemonaid tmux new [name]` - Create a new tmux session from a template
+
+## Scratch Pane
+
+The scratch pane provides an always-available lma inbox that can be toggled with a keybinding. Unlike running `lma` in a popup, the scratch pane stays running in the background, so there's no startup delay when showing it.
+
+### Setup
+
+Add to your `~/.tmux.conf`:
+
+```tmux
+# Toggle scratch lma pane
+bind-key l run-shell 'lemonaid tmux scratch'
+```
+
+Reload tmux config:
+
+```bash
+tmux source-file ~/.tmux.conf
+```
+
+### Usage
+
+1. Press `prefix + l` to show the lma inbox as a split at the top of your current window
+2. Select a notification with Enter - you'll switch to that session and the lma pane auto-hides
+3. Press `prefix + l` again to bring it back
+
+### How it works
+
+1. First toggle creates a tmux session (`_lma_scratch`) running `lma --scratch`
+2. The pane is joined into your current window as a 30% top split
+3. When you select a notification, lma auto-dismisses by breaking the pane to its own window
+4. Subsequent toggles show/hide the same pane (no restart, instant response)
+
+State is tracked per tmux server in `~/.local/state/lemonaid/scratch-pane-<server>.json`, so multiple tmux servers won't conflict.
+
+### Options
+
+```bash
+# Customize the pane height
+lemonaid tmux scratch --height 40%
+
+# See what action was taken
+lemonaid tmux scratch -v  # prints: created, shown, or hidden
+```
 
 ## Session Templates
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.1.1"
+version = "0.2.0"
 description = "Attention inbox for managing notifications from LLMs and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/cli.py
+++ b/src/lemonaid/cli.py
@@ -122,9 +122,19 @@ def main() -> None:
 
 def inbox_main() -> None:
     """Direct entry point for `lma` alias - goes straight to inbox TUI."""
+    import argparse
+
     from .inbox.tui import LemonaidApp
 
-    app = LemonaidApp()
+    parser = argparse.ArgumentParser(prog="lma", description="Lemonaid attention inbox")
+    parser.add_argument(
+        "--scratch",
+        action="store_true",
+        help="Run as a scratch pane: auto-hide after selecting a notification",
+    )
+    args = parser.parse_args()
+
+    app = LemonaidApp(scratch_mode=args.scratch)
     app.run()
 
 

--- a/src/lemonaid/tmux/cli.py
+++ b/src/lemonaid/tmux/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..config import load_config
 from . import go_back, swap_back_location
+from .scratch import toggle_scratch
 from .session import create_session
 
 
@@ -27,6 +28,14 @@ def cmd_swap(args: argparse.Namespace) -> None:
     target_session, target_pane = swap_back_location(args.session, args.pane_id)
     if target_session is not None and target_pane is not None:
         print(f"{target_session}|{target_pane}")
+
+
+def cmd_scratch(args: argparse.Namespace) -> None:
+    """Toggle the scratch lma pane."""
+    result = toggle_scratch(height=args.height)
+    # Optionally print result for debugging
+    if args.verbose:
+        print(result)
 
 
 def cmd_new(args: argparse.Namespace) -> None:
@@ -81,6 +90,26 @@ def setup_parser(subparsers: argparse._SubParsersAction) -> None:
     swap_parser.add_argument("session", help="Current session name")
     swap_parser.add_argument("pane_id", help="Current pane ID (e.g., %5)")
     swap_parser.set_defaults(func=cmd_swap)
+
+    # tmux scratch - toggle scratch pane
+    scratch_parser = tmux_subparsers.add_parser(
+        "scratch",
+        help="Toggle the scratch lma pane (show/hide)",
+        description="Toggle a persistent lma pane that stays running. "
+        "First invocation creates it, subsequent invocations show/hide it.",
+    )
+    scratch_parser.add_argument(
+        "--height",
+        default="30%",
+        help="Height of the scratch pane when shown (default: 30%%)",
+    )
+    scratch_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print action taken (created/shown/hidden)",
+    )
+    scratch_parser.set_defaults(func=cmd_scratch)
 
     # tmux new - create session from template
     new_parser = tmux_subparsers.add_parser(

--- a/src/lemonaid/tmux/scratch.py
+++ b/src/lemonaid/tmux/scratch.py
@@ -1,0 +1,189 @@
+"""Scratch pane functionality for lemonaid.
+
+Provides a toggleable "always-on" lma pane that can be shown/hidden
+without restarting the TUI (avoiding startup latency).
+
+State is tracked per tmux server in ~/.local/state/lemonaid/scratch-pane-<server>.json
+to avoid conflicts when running multiple tmux servers.
+"""
+
+import json
+import os
+import subprocess
+
+from . import get_state_path
+
+_SCRATCH_SESSION = "_lma_scratch"
+
+
+def _get_server_name() -> str:
+    """Get the tmux server name from TMUX env var.
+
+    TMUX format: /path/to/socket,pid,pane_index
+    Returns the socket basename (e.g., 'default' for the default server).
+    """
+    tmux_env = os.environ.get("TMUX", "")
+    if tmux_env:
+        socket_path = tmux_env.split(",")[0]
+        return os.path.basename(socket_path)
+    return "default"
+
+
+def _get_state() -> dict | None:
+    """Load scratch pane state (pane_id of the lma pane)."""
+    path = get_state_path() / f"scratch-pane-{_get_server_name()}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def _save_state(pane_id: str) -> None:
+    """Save scratch pane state."""
+    path = get_state_path() / f"scratch-pane-{_get_server_name()}.json"
+    path.write_text(json.dumps({"pane_id": pane_id}))
+
+
+def _clear_state() -> None:
+    """Clear scratch pane state."""
+    path = get_state_path() / f"scratch-pane-{_get_server_name()}.json"
+    if path.exists():
+        path.unlink()
+
+
+def _pane_exists(pane_id: str) -> bool:
+    """Check if a pane still exists."""
+    result = subprocess.run(
+        ["tmux", "display-message", "-t", pane_id, "-p", "#{pane_id}"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _get_pane_window(pane_id: str) -> str | None:
+    """Get the window ID that contains a pane."""
+    result = subprocess.run(
+        ["tmux", "display-message", "-t", pane_id, "-p", "#{window_id}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return None
+
+
+def _get_current_window() -> str | None:
+    """Get the current window ID."""
+    result = subprocess.run(
+        ["tmux", "display-message", "-p", "#{window_id}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return None
+
+
+def _session_exists() -> bool:
+    """Check if the scratch tmux session exists."""
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", _SCRATCH_SESSION],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _get_session_pane() -> str | None:
+    """Get the pane ID of the first pane in the scratch session."""
+    result = subprocess.run(
+        ["tmux", "list-panes", "-t", _SCRATCH_SESSION, "-F", "#{pane_id}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout.strip().split("\n")[0]
+    return None
+
+
+def _create_pane() -> str:
+    """Create the scratch pane with lma running. Returns pane_id."""
+    # Check if session already exists (recovery: state file lost but session exists)
+    if _session_exists():
+        pane_id = _get_session_pane()
+        if pane_id:
+            _save_state(pane_id)
+            return pane_id
+
+    # Create a new session with lma in scratch mode
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", _SCRATCH_SESSION, "lma", "--scratch"],
+        check=True,
+    )
+
+    result = subprocess.run(
+        ["tmux", "list-panes", "-t", _SCRATCH_SESSION, "-F", "#{pane_id}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pane_id = result.stdout.strip()
+    _save_state(pane_id)
+    return pane_id
+
+
+def _show(pane_id: str, height: str) -> bool:
+    """Join the scratch pane into current window as a top split."""
+    result = subprocess.run(
+        ["tmux", "join-pane", "-v", "-b", "-l", height, "-s", pane_id],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _hide(pane_id: str) -> bool:
+    """Break the scratch pane to its own window."""
+    result = subprocess.run(
+        ["tmux", "break-pane", "-d", "-s", pane_id],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _create_and_show(height: str) -> str:
+    """Create a fresh scratch pane and show it."""
+    _clear_state()
+    if _session_exists():
+        subprocess.run(
+            ["tmux", "kill-session", "-t", _SCRATCH_SESSION],
+            capture_output=True,
+        )
+    pane_id = _create_pane()
+    _show(pane_id, height)
+    return "created"
+
+
+def toggle_scratch(height: str = "30%") -> str:
+    """Toggle the scratch lma pane. Returns 'shown', 'hidden', or 'created'."""
+    state = _get_state()
+
+    if state is None:
+        return _create_and_show(height)
+
+    pane_id = state["pane_id"]
+
+    if not _pane_exists(pane_id):
+        return _create_and_show(height)
+
+    current_window = _get_current_window()
+    pane_window = _get_pane_window(pane_id)
+
+    if pane_window == current_window:
+        if not _hide(pane_id):
+            return _create_and_show(height)
+        return "hidden"
+    else:
+        if not _show(pane_id, height):
+            return _create_and_show(height)
+        return "shown"


### PR DESCRIPTION
Adds `lemonaid tmux scratch` command that toggles a persistent lma pane:
- First toggle creates lma in a background session, joins it as a top split
- lma auto-dismisses after selecting a notification (--scratch flag)
- Subsequent toggles instantly show/hide without restart delay
- State tracked per tmux server to avoid conflicts