### PR TITLE
feat: add transcript watcher for reliable auto-dismiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,6 @@ Add these hooks to your `~/.claude/settings.json`:
 ```json
 {
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "lemonaid claude dismiss"
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [
@@ -94,32 +84,26 @@ Add these hooks to your `~/.claude/settings.json`:
           }
         ]
       }
-    ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "lemonaid claude dismiss"
-          }
-        ]
-      }
     ]
   }
 }
 ```
 
 This gives you:
-- **Stop hook**: Notification when Claude finishes responding
+- **Stop hook**: Notification when Claude finishes responding and is waiting for input
 - **Notification hook**: Notification when Claude needs permission
-- **UserPromptSubmit hook**: Dismisses notification when you send a message
-- **PreToolUse hook** (recommended): Dismisses notification whenever Claude runs a tool
 
-The `PreToolUse` hook is important because granting a permission prompt doesn't trigger `UserPromptSubmit`. Without it, you'll see stale "permission needed" notifications after granting permission, since Claude continues working but the notification remains unread until your next prompt.
+### Auto-dismiss via transcript watching
 
-**Known limitation**: There's no Claude Code hook for "permission granted" or "Claude is thinking." After you grant a permission, Claude may think for a few seconds before invoking the next tool. During this gap, no hook fires, so the notification briefly stays unread. This is unavoidable with current Claude Code hook events.
+Lemonaid automatically monitors Claude's transcript files to detect when you provide input. When Claude starts working (thinking, running tools), the notification is dismissed automatically. This is more reliable than hook-based dismiss because:
 
-**Faster notifications**: Claude Code has a hardcoded 6-second polling interval for notification hooks, causing ~10 second delays. Lemonaid can patch the binary to reduce this to 500ms - see [docs/claude-patch.md](docs/claude-patch.md).
+- No race conditions with the Stop hook
+- Works for all input types (prompts, permission grants, etc.)
+- No additional hooks needed (reduces overhead on every tool call)
+
+The transcript watcher starts automatically when the TUI runs.
+
+**Faster notifications**: Claude Code has a hardcoded 6-second polling interval for notification hooks, causing delays. Lemonaid can patch the binary to reduce this to 500ms - see [docs/claude-patch.md](docs/claude-patch.md).
 
 ## Terminal Setup
 

--- a/src/lemonaid/claude/__init__.py
+++ b/src/lemonaid/claude/__init__.py
@@ -1,1 +1,21 @@
 """Lemonaid Claude Code integration."""
+
+from pathlib import Path
+
+
+def cwd_to_project_dir(cwd: str) -> str:
+    """Convert a cwd path to Claude's project directory format.
+
+    /Users/peter.gaultney/play/lemonaid -> -Users-peter-gaultney-play-lemonaid
+
+    Claude replaces / and . with - in the directory name.
+    """
+    project_dir = cwd.replace("/", "-").replace(".", "-")
+    if project_dir.startswith("-"):
+        project_dir = project_dir[1:]
+    return "-" + project_dir
+
+
+def get_project_path(cwd: str) -> Path:
+    """Get the Claude project directory path for a given cwd."""
+    return Path.home() / ".claude" / "projects" / cwd_to_project_dir(cwd)

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -132,15 +132,10 @@ def get_session_name(session_id: str, cwd: str) -> str | None:
     if not session_id or not cwd:
         return None
 
-    # Convert cwd to project directory name
-    # /Users/peter.gaultney/play/lemonaid -> -Users-peter-gaultney-play-lemonaid
-    project_dir = cwd.replace("/", "-")
-    if project_dir.startswith("-"):
-        project_dir = project_dir[1:]  # Remove leading dash
-    project_dir = "-" + project_dir  # Add it back (consistent format)
+    from . import get_project_path
 
     # Try sessions-index.json first
-    sessions_index_path = Path.home() / ".claude" / "projects" / project_dir / "sessions-index.json"
+    sessions_index_path = get_project_path(cwd) / "sessions-index.json"
     if sessions_index_path.exists():
         try:
             data = json.loads(sessions_index_path.read_text())

--- a/src/lemonaid/claude/watcher.py
+++ b/src/lemonaid/claude/watcher.py
@@ -1,0 +1,154 @@
+"""Transcript watcher for Claude Code sessions.
+
+Monitors transcript files to detect when Claude becomes active (working),
+which indicates the user has provided input and notifications should be dismissed.
+"""
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+
+def get_transcript_path(cwd: str, session_id: str) -> Path | None:
+    """Construct the transcript path from cwd and session_id."""
+    if not cwd or not session_id:
+        return None
+
+    from . import get_project_path
+
+    transcript_path = get_project_path(cwd) / f"{session_id}.jsonl"
+    return transcript_path if transcript_path.exists() else None
+
+
+def should_dismiss(entry: dict) -> bool:
+    """Check if a transcript entry indicates Claude is active (should dismiss).
+
+    Returns True for:
+    - assistant entries (thinking, tool_use, text) - Claude is working
+    - user entries with actual user messages (not tool_result) - user sent input
+    """
+    entry_type = entry.get("type")
+
+    if entry_type == "assistant":
+        return True
+
+    if entry_type == "user":
+        message = entry.get("message", {})
+        content = message.get("content")
+        # Real user messages have string content
+        if isinstance(content, str):
+            return True
+
+    return False
+
+
+def check_transcript_for_activity(transcript_path: Path, since_time: float) -> bool:
+    """Check if transcript has dismiss-worthy activity since given timestamp.
+
+    Args:
+        transcript_path: Path to the .jsonl transcript
+        since_time: Unix timestamp - only consider entries after this
+
+    Returns:
+        True if activity detected that should dismiss notification
+    """
+    try:
+        file_size = transcript_path.stat().st_size
+        # Only read last 64KB - enough for recent entries
+        read_size = min(file_size, 64 * 1024)
+
+        with open(transcript_path) as f:
+            if file_size > read_size:
+                f.seek(file_size - read_size)
+                f.readline()  # Skip partial line
+            content = f.read()
+
+        from datetime import datetime
+
+        for line in reversed(content.strip().split("\n")[-50:]):
+            try:
+                entry = json.loads(line)
+                ts_str = entry.get("timestamp", "")
+                if ts_str:
+                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+                    if ts > since_time and should_dismiss(entry):
+                        return True
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+        return False
+    except OSError:
+        return False
+
+
+def watch_loop(
+    get_unread: Callable[
+        [], list[tuple[str, str, str, float]]
+    ],  # -> [(channel, session_id, cwd, created_at), ...]
+    dismiss: Callable[[str], int],  # channel -> count dismissed
+    poll_interval: float = 0.5,
+) -> None:
+    """Main watch loop - runs forever, checking transcripts for unread notifications.
+
+    Args:
+        get_unread: Callback returning list of (channel, session_id, cwd, created_at) for unread notifications
+        dismiss: Callback to dismiss a channel, returns count dismissed
+        poll_interval: How often to poll (seconds)
+    """
+    log_file = Path("/tmp/lemonaid-watcher.log")
+
+    def log(msg: str):
+        with open(log_file, "a") as f:
+            f.write(f"[{time.strftime('%H:%M:%S')}] {msg}\n")
+
+    log("watcher started")
+
+    while True:
+        try:
+            unread = get_unread()
+
+            for channel, session_id, cwd, created_at in unread:
+                if not channel.startswith("claude:"):
+                    continue
+
+                transcript_path = get_transcript_path(cwd, session_id)
+                if not transcript_path:
+                    continue
+
+                if check_transcript_for_activity(transcript_path, created_at):
+                    count = dismiss(channel)
+                    if count > 0:
+                        log(f"dismissed {channel} via transcript activity")
+
+        except Exception as e:
+            log(f"error: {e}")
+
+        time.sleep(poll_interval)
+
+
+_watcher_thread: threading.Thread | None = None
+
+
+def start_watcher(
+    get_unread: Callable[[], list[tuple[str, str, str, float]]],
+    dismiss: Callable[[str], int],
+) -> None:
+    """Start the transcript watcher daemon thread.
+
+    Args:
+        get_unread: Callback returning list of (channel, session_id, cwd, created_at) for unread notifications
+        dismiss: Callback to dismiss a channel, returns count dismissed
+    """
+    global _watcher_thread
+
+    if _watcher_thread is not None and _watcher_thread.is_alive():
+        return  # Already running
+
+    _watcher_thread = threading.Thread(
+        target=watch_loop,
+        args=(get_unread, dismiss),
+        daemon=True,
+    )
+    _watcher_thread.start()

--- a/src/lemonaid/inbox/tui.py
+++ b/src/lemonaid/inbox/tui.py
@@ -88,17 +88,20 @@ class LemonaidApp(App):
             self.query_one(DataTable).styles.background = "transparent"
 
         self._setup_table()
-        self._check_claude_patch()
         self._refresh_notifications()
         # Auto-refresh every 2 seconds
         self.set_interval(1.0, self._refresh_notifications)
         # Start transcript watcher for auto-dismiss
         start_watcher(get_unread=self._get_unread_for_watcher, dismiss=self._dismiss_channel)
+        # Check Claude patch status after initial render (reads 180MB binary)
+        self.call_later(self._check_claude_patch)
 
     def _check_claude_patch(self) -> None:
         """Check Claude Code patch status."""
         if self._claude_binary:
             self._claude_patch_status = check_status(self._claude_binary)
+            # Update status bar to show patch warning if needed
+            self._refresh_notifications()
         else:
             self._claude_patch_status = None
 


### PR DESCRIPTION
## Transcript Watcher for Auto-Dismiss

Previously, lemonaid relied on Claude Code hooks (`UserPromptSubmit`, `PreToolUse`) to dismiss notifications when the user provided input. This had race conditions with the `Stop` hook - often the Stop hook would fire after dismiss and recreate the notification.

Now the TUI monitors Claude transcript files directly. When we see Claude start working (thinking, tool calls, etc.) or a new user message, we dismiss the notification immediately. This is more reliable because:

- **No race conditions** - we see activity in the transcript before any hooks fire
- **Works for all input types** - prompts, permission grants, clicking Allow, etc.
- **Less overhead** - no dismiss hooks needed on every tool call

The watcher runs as a daemon thread when the TUI is open, polling transcripts every 500ms (only reading the last 64KB for efficiency).

### Hook changes

Users no longer need `PreToolUse` or `UserPromptSubmit` dismiss hooks. The recommended config is now just the notify hooks (Stop, Notification).

---

## Claude Patcher Fixes for v2.1.16+

Claude Code v2.1.16+ uses different minified variable names per build, so the hardcoded `spB=6000` pattern no longer works. The patcher now:

- Dynamically finds the polling interval pattern by searching for `XXX=6000` near `notificationType` marker
- Supports checking both patched and unpatched states
- Falls back to hardcoded patterns for older versions

Also defers the patch status check to after initial TUI render, since reading the 180MB Claude binary was slowing down startup.