### PR TITLE
simplify: switch-source based handler selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,21 @@
+# 0.5.0 (2026-01-26)
+
+#### Added
+
+- **Show all sources**: New `show_all_sources = true` TUI config option shows sessions from other terminal environments (e.g., wezterm sessions when in tmux) in a separate non-interactive section below the main table. Lets you monitor all sessions without cluttering navigation.
+- **Auto-archive dead panes**: Watcher now archives notifications whose panes no longer exist, in addition to process exit detection.
+
+#### Changed
+
+- **Switch-source based handlers**: Handler selection now uses the notification's `switch_source` (where it came from) instead of channel pattern matching. Built-in handlers (tmux, wezterm) are auto-selected based on switch-source. No `[handlers]` config needed.
+- **Renamed `terminal_env` to `switch_source`**: The database column and API field are renamed to better reflect the concept: the switch-source determines which switch-handler can navigate back to the notification's origin.
+- **Renamed `detect_terminal_env()` to `detect_terminal_switch_source()`**: More explicit naming.
+- **Removed `exec:` handlers**: Will be reintroduced as hooks in a future release.
+
+#### Migration
+
+- Database migration automatically renames the `terminal_env` column to `switch_source`
+
 ## 0.4.10 (2026-01-26)
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -100,14 +100,6 @@ For JSON output and programmatic access (useful for lemons), see [docs/for-lemon
 
 Config file: `~/.config/lemonaid/config.toml`
 
-```toml
-[handlers]
-# Map channel patterns to handlers
-"claude:*" = "tmux"  # or "wezterm"
-"codex:*" = "tmux"
-```
-
-See also:
 - [docs/keybindings.md](docs/keybindings.md) - Customize TUI keybindings
 - [docs/tmux.md](docs/tmux.md) - tmux-specific options
 - [docs/wezterm.md](docs/wezterm.md) - WezTerm-specific options
@@ -115,6 +107,6 @@ See also:
 ## Architecture
 
 - **inbox**: SQLite-backed notification storage with Textual TUI
-- **handlers**: Pluggable system for handling notifications (`tmux`, WezTerm, exec)
+- **handlers**: Auto-selects switch-handler based on notification's switch-source (tmux, wezterm)
 - **claude**: Claude Code hook integration with transcript watching
 - **codex**: Codex CLI hook integration with session watching

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -40,15 +40,6 @@ This gives you:
 - **Stop hook**: Notification when Claude finishes responding and is waiting for input
 - **Notification hook**: Notification when Claude needs permission
 
-### 2. Configure lemonaid handler
-
-In `~/.config/lemonaid/config.toml`:
-
-```toml
-[handlers]
-"claude:*" = "tmux"  # or "wezterm"
-```
-
 ## How it works
 
 ### Notification flow

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -18,17 +18,6 @@ notify = ["lemonaid", "codex", "notify"]
 
 **Important**: In TOML, anything after a `[table]` header belongs to that table. The `notify` setting must appear before any tables to be recognized as a root-level setting.
 
-### 2. Configure lemonaid handler (optional)
-
-In `~/.config/lemonaid/config.toml`:
-
-```toml
-[handlers]
-"codex:*" = "tmux"  # or "wezterm"
-```
-
-If not configured, Codex notifications will still appear in the inbox but won't auto-switch to the pane.
-
 ## How it works
 
 ### Notification flow

--- a/docs/for-lemons.md
+++ b/docs/for-lemons.md
@@ -23,7 +23,7 @@ Output:
     "status": "unread",
     "created_at": 1768578211.645825,
     "read_at": null,
-    "terminal_env": "tmux"
+    "switch_source": "tmux"
   }
 ]
 ```
@@ -60,4 +60,4 @@ lemonaid inbox add "channel-name" "Title" -m "Optional message" --metadata '{"ke
 | `status` | string | `unread`, `read`, or `archived` |
 | `created_at` | float | Unix timestamp |
 | `read_at` | float? | Unix timestamp when marked read |
-| `terminal_env` | string? | Terminal environment: `tmux`, `wezterm`, or `null` |
+| `switch_source` | string? | Switch-source: `tmux`, `wezterm`, or `null` (determines which switch-handler can navigate back) |

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -4,16 +4,9 @@ Lemonaid integrates with tmux to switch directly to the session and pane where a
 
 ## Setup
 
-### 1. Configure lemonaid to use tmux
+Lemonaid automatically detects when notifications come from tmux and uses the tmux switch-handler. No configuration needed.
 
-In `~/.config/lemonaid/config.toml`:
-
-```toml
-[handlers]
-"claude:*" = "tmux"
-```
-
-### 2. Add a back-navigation keybinding (optional but recommended)
+### Add a back-navigation keybinding (optional but recommended)
 
 Add to your `~/.tmux.conf`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.4.10"
+version = "0.5.0"
 description = "Attention inbox for managing notifications from LLMs and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from ..inbox import db
 from ..lemon_watchers import (
-    detect_terminal_env,
+    detect_terminal_switch_source,
     get_name_from_cwd,
     get_tmux_session_name,
     get_tty,
@@ -125,8 +125,8 @@ def handle_notification(stdin_data: str | None = None) -> None:
     # Look up session name: Claude name > tmux session name > cwd-derived name
     name = get_session_name(session_id, cwd) or get_tmux_session_name() or get_name_from_cwd(cwd)
 
-    # Detect terminal environment
-    terminal_env = detect_terminal_env()
+    # Detect switch-source (which terminal environment this notification came from)
+    switch_source = detect_terminal_switch_source()
 
     # Build metadata for handler
     metadata = {
@@ -155,7 +155,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
             message=message,
             name=name,
             metadata=metadata,
-            terminal_env=terminal_env if terminal_env != "unknown" else None,
+            switch_source=switch_source if switch_source != "unknown" else None,
         )
 
     with open(log_file, "a") as f:

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -18,13 +18,10 @@ def get_default_config() -> str:
     return """\
 # Lemonaid configuration
 
-[handlers]
-# Map channel patterns to handlers
-# Supported handlers: "wezterm", "exec:<command>"
-"claude:*" = "wezterm"
+# Switch-handlers are auto-selected based on the notification's switch-source.
+# No configuration needed for tmux/wezterm - they just work.
 
 [wezterm]
-# WezTerm handler settings
 # How to resolve pane from notification metadata
 # Options: "tty" (match TTY to pane), "metadata" (use workspace/pane_id from metadata)
 resolve_pane = "tty"
@@ -76,6 +73,7 @@ class TuiConfig:
     """Configuration for the TUI."""
 
     transparent: bool = False  # Use ANSI colors for terminal transparency
+    show_all_sources: bool = False  # Show sessions from all sources (tmux+wezterm)
     keybindings: KeybindingsConfig = field(default_factory=KeybindingsConfig)
 
 
@@ -133,12 +131,15 @@ def _parse_config(data: dict[str, Any]) -> Config:
     keybindings_data = tui_data.get("keybindings", {})
     # Use dataclass defaults for any unspecified keybindings
     defaults = KeybindingsConfig()
-    keybindings = KeybindingsConfig(**{
-        field: keybindings_data.get(field, getattr(defaults, field))
-        for field in defaults.__dataclass_fields__
-    })
+    keybindings = KeybindingsConfig(
+        **{
+            field: keybindings_data.get(field, getattr(defaults, field))
+            for field in defaults.__dataclass_fields__
+        }
+    )
     tui = TuiConfig(
         transparent=tui_data.get("transparent", False),
+        show_all_sources=tui_data.get("show_all_sources", False),
         keybindings=keybindings,
     )
 

--- a/src/lemonaid/inbox/migrations/m003_rename_terminal_env.py
+++ b/src/lemonaid/inbox/migrations/m003_rename_terminal_env.py
@@ -1,0 +1,15 @@
+"""Rename terminal_env column to switch_source.
+
+This reflects the new terminology: the switch-source determines which
+switch-handler can navigate back to the notification's origin.
+"""
+
+import sqlite3
+
+VERSION = 3
+DESCRIPTION = "Rename terminal_env to switch_source"
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    """Rename terminal_env column to switch_source."""
+    conn.execute("ALTER TABLE notifications RENAME COLUMN terminal_env TO switch_source")

--- a/src/lemonaid/inbox/tui/utils.py
+++ b/src/lemonaid/inbox/tui/utils.py
@@ -16,4 +16,5 @@ def styled_cell(value: str, is_unread: bool) -> Text:
     """Style a cell value based on read/unread status."""
     if is_unread:
         return Text(value, style="bold cyan")
+
     return Text(value, style="dim")

--- a/src/lemonaid/lemon_watchers/__init__.py
+++ b/src/lemonaid/lemon_watchers/__init__.py
@@ -1,7 +1,7 @@
 """Shared utilities and unified watcher for LLM session monitoring."""
 
 from .common import (
-    detect_terminal_env,
+    detect_terminal_switch_source,
     get_name_from_cwd,
     get_tmux_session_name,
     get_tty,
@@ -19,7 +19,7 @@ from .watcher import (
 
 __all__ = [
     "WatcherBackend",
-    "detect_terminal_env",
+    "detect_terminal_switch_source",
     "get_latest_activity",
     "get_name_from_cwd",
     "get_tmux_session_name",

--- a/src/lemonaid/lemon_watchers/common.py
+++ b/src/lemonaid/lemon_watchers/common.py
@@ -55,10 +55,11 @@ def get_tty() -> str | None:
     return None
 
 
-def detect_terminal_env() -> str:
-    """Detect which terminal environment we're running in.
+def detect_terminal_switch_source() -> str:
+    """Detect the switch-source for this terminal environment.
 
-    Returns one of: 'tmux', 'wezterm', or 'unknown'.
+    The switch-source determines which switch-handler can navigate
+    back to this terminal. Returns one of: 'tmux', 'wezterm', or 'unknown'.
     """
     if os.environ.get("TMUX"):
         return "tmux"

--- a/thoughts.md
+++ b/thoughts.md
@@ -133,7 +133,7 @@ open "$URL"
 
 ### Implementation Phases
 
-1. **Documentation** (current) - Capture design thinking
-2. **Rename and simplify** - `terminal_env` → `switch_source`, auto-select handler
-3. **Actionability check** - Verify pane exists before marking as actionable
-4. **Custom handlers** - Support external scripts for non-terminal sources
+1. [x] **Documentation** - Capture design thinking
+2. [x] **Rename and simplify** - `terminal_env` → `switch_source`, auto-select handler
+3. [x] **Actionability check** - Verify pane exists before marking as actionable
+4. [ ] **Custom handlers** - Support external scripts for non-terminal sources


### PR DESCRIPTION
Switch-handlers are now auto-selected based on the notification's switch-source (where it originated) rather than channel pattern matching.

Key changes:
- Rename terminal_env to switch_source (with DB migration)
- Rename detect_terminal_env() to detect_switch_source()
- Handler selection uses switch_source instead of channel patterns
- Remove exec: handlers (will be reintroduced as hooks later)
- Update docs to reflect simpler config (no [handlers] section needed)
