### PR TITLE
fix: watcher syncs DB with transcript when notify handler overwrites

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.4.10 (2026-01-26)
+
+#### Changed
+
+- **Watcher uses transcript timestamps for caching**: Watcher now caches the timestamp of the last transcript entry processed (not just the message string). This allows proper detection of new activity vs. polling the same state. When timestamp is unchanged, watcher doesn't overwrite DB - this preserves legitimate "Permission needed" messages while still updating when Claude makes progress.
+
 ## 0.4.9 (2026-01-26)
 
 #### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,3 @@
-## 0.4.10 (2026-01-26)
-
-#### Fixed
-
-- **Stale permission prompt filtering**: Notification handler now checks the transcript before upserting. If Claude has already moved on (has activity after the permission request), the stale notification is skipped. Fixes "Permission needed" message persisting after user responds.
-
 ## 0.4.9 (2026-01-26)
 
 #### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.4.10"
+version = "0.4.9"
 description = "Attention inbox for managing notifications from LLMs and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.4.9"
+version = "0.4.10"
 description = "Attention inbox for managing notifications from LLMs and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -389,10 +389,10 @@ class LemonaidApp(App):
 
     def _get_active_for_watcher(
         self,
-    ) -> list[tuple[str, str, str, float, bool, str | None]]:
+    ) -> list[tuple[str, str, str, float, bool, str | None, str]]:
         """Get active notifications for the transcript watcher.
 
-        Returns list of (channel, session_id, cwd, created_at, is_unread, tty).
+        Returns list of (channel, session_id, cwd, created_at, is_unread, tty, message).
         """
         with db.connect() as conn:
             env_filter = self.terminal_env if self.terminal_env != "unknown" else None
@@ -405,7 +405,7 @@ class LemonaidApp(App):
             tty = n.metadata.get("tty")
             if session_id and cwd:
                 result.append(
-                    (n.channel, session_id, cwd, n.created_at, n.is_unread, tty)
+                    (n.channel, session_id, cwd, n.created_at, n.is_unread, tty, n.message)
                 )
         return result
 

--- a/tests/test_lemon_watchers.py
+++ b/tests/test_lemon_watchers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from lemonaid.lemon_watchers import (
     get_latest_activity,
@@ -14,15 +14,15 @@ from lemonaid.lemon_watchers import (
 
 def test_parse_timestamp_zulu():
     ts = parse_timestamp("2026-01-24T12:34:56Z")
-    assert ts == datetime(2026, 1, 24, 12, 34, 56, tzinfo=timezone.utc).timestamp()
+    assert ts == datetime(2026, 1, 24, 12, 34, 56, tzinfo=UTC).timestamp()
 
 
 def test_get_latest_activity_reads_tail(tmp_path):
     session = tmp_path / "session.jsonl"
     entries = [
         {"type": "noise"},
-        {"type": "message", "text": "first"},
-        {"type": "message", "text": "second"},
+        {"type": "message", "text": "first", "timestamp": "2026-01-26T10:00:00"},
+        {"type": "message", "text": "second", "timestamp": "2026-01-26T10:00:01"},
     ]
     session.write_text("\n".join(json.dumps(e) for e in entries))
 
@@ -31,7 +31,8 @@ def test_get_latest_activity_reads_tail(tmp_path):
             return entry.get("text")
         return None
 
-    assert get_latest_activity(session, describe) == "second"
+    result = get_latest_activity(session, describe)
+    assert result == ("second", "2026-01-26T10:00:01")
 
 
 def test_has_activity_since(tmp_path):
@@ -42,8 +43,8 @@ def test_has_activity_since(tmp_path):
     ]
     session.write_text("\n".join(json.dumps(e) for e in entries))
 
-    since = datetime(2026, 1, 24, 12, 0, 30, tzinfo=timezone.utc).timestamp()
+    since = datetime(2026, 1, 24, 12, 0, 30, tzinfo=UTC).timestamp()
     assert has_activity_since(session, since, lambda e: e.get("type") == "dismiss")
 
-    since = datetime(2026, 1, 24, 12, 2, 0, tzinfo=timezone.utc).timestamp()
+    since = datetime(2026, 1, 24, 12, 2, 0, tzinfo=UTC).timestamp()
     assert not has_activity_since(session, since, lambda e: e.get("type") == "dismiss")


### PR DESCRIPTION
## Summary

- Watcher now detects when notify handler has overwritten the DB message
- Uses transcript entry timestamps to distinguish "new activity" from "same activity, DB changed"
- Fixes "Permission needed" message persisting after user responds and Claude continues working

## The Problem

1. Watcher updates DB to "Running kubectl"
2. Notify handler fires late, overwrites DB to "Permission needed"
3. Watcher's cache had ("Running kubectl", T1)
4. Next poll: transcript still at T1, watcher sees timestamp unchanged, doesn't update
5. "Permission needed" persists even though Claude is working

## The Fix

- `get_latest_activity` returns `(message, timestamp)` tuple
- `get_active` now includes `db_message` 
- Watcher compares transcript message to DB message when timestamp unchanged
- If they differ, updates DB to match transcript

## Test plan

- [x] Run existing tests
- [x] Test with real Claude session that triggers permission prompts
- [x] Verify "Permission needed" doesn't persist after responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)