### PR TITLE
feat: macOS Notification Center integration with Slack deep linking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# 0.6.0 (2026-01-27)
+
+#### Added
+
+- **macOS Notification Center integration**: Capture Slack notifications via the Accessibility API and add them to the lemonaid inbox. Install the watcher daemon with `lemonaid macos install-watcher`. Requires `uv pip install lemonaid[macos]` for PyObjC dependencies.
+- **Notification deduplication**: Notifications include macOS accessibility IDs (`ax_id`) in metadata. Once marked as read, the same notification won't resurface if macOS re-fires it.
+- **Slack deep linking**: Pressing Enter on Slack notifications opens a `slack://` deep link directly to the conversation. Add `[slack]` to your config to enable. Requires manually exporting channel mappings from Slack's browser IndexedDB (see `docs/macos.md` for instructions).
+- **Multi-workspace support**: Slack mappings support multiple workspaces. Deep links automatically use the correct team ID based on the notification's workspace.
+
 # 0.5.0 (2026-01-26)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ Features: auto-dismiss via session watching, live activity updates.
 
 **Full documentation**: [docs/codex.md](docs/codex.md)
 
+### Slack (macOS)
+
+Capture Slack notifications and deep-link directly to conversations:
+
+```bash
+# Install macOS dependencies
+uv tool install --editable ~/play/lemonaid \
+  --with pyobjc-framework-Quartz \
+  --with pyobjc-framework-ApplicationServices
+
+# Install the notification watcher daemon
+lemonaid macos install-watcher
+
+# Enable Slack in config
+echo '[slack]' >> ~/.config/lemonaid/config.toml
+```
+
+When you select a Slack notification, lemonaid opens a `slack://` deep link directly to that channel/DM.
+
+Deep linking requires a manually-exported mappings file with channel IDs. See [docs/macos.md](docs/macos.md) for the browser-based export process.
+
+**Full documentation**: [docs/macos.md](docs/macos.md)
+
 ## Terminal Setup
 
 - **`tmux`**: See [docs/tmux.md](docs/tmux.md) for pane switching, back navigation, session templates, and window colors
@@ -104,9 +127,18 @@ Config file: `~/.config/lemonaid/config.toml`
 - [docs/tmux.md](docs/tmux.md) - tmux-specific options
 - [docs/wezterm.md](docs/wezterm.md) - WezTerm-specific options
 
+## Data Locations
+
+- **Database**: `~/.local/share/lemonaid/lemonaid.db`
+- **Logs**: `~/.local/state/lemonaid/logs/`
+- **Config**: `~/.config/lemonaid/config.toml`
+- **Slack mappings**: `~/.local/state/lemonaid/slack-mappings.json`
+
 ## Architecture
 
 - **inbox**: SQLite-backed notification storage with Textual TUI
-- **handlers**: Auto-selects switch-handler based on notification's switch-source (tmux, wezterm)
+- **handlers**: Auto-selects switch-handler based on notification's switch-source (tmux, wezterm, slack)
 - **claude**: Claude Code hook integration with transcript watching
 - **codex**: Codex CLI hook integration with session watching
+- **macos**: Notification Center watcher daemon using Accessibility API
+- **slack**: Deep linking to Slack channels/DMs via manually-exported channel mappings

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,233 @@
+# macOS Notification Center Integration
+
+Lemonaid can capture notifications from macOS Notification Center and add them to your inbox. This is useful for monitoring Slack messages (and potentially other apps) without keeping those apps in focus.
+
+## Requirements
+
+- macOS (tested on macOS 14+)
+- Accessibility permissions (for reading Notification Center)
+- PyObjC dependencies
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+# With uv (recommended):
+uv pip install lemonaid[macos]
+
+# Or with pip:
+pip install lemonaid[macos]
+```
+
+If using `uv tool install`:
+```bash
+uv tool install --editable path/to/lemonaid \
+  --with pyobjc-framework-Quartz \
+  --with pyobjc-framework-ApplicationServices
+```
+
+The `macos` extra provides the notification watcher daemon.
+
+### 2. Install and start the watcher daemon
+
+```bash
+lemonaid macos install-watcher
+```
+
+This:
+1. Creates a LaunchAgent plist at `~/Library/LaunchAgents/com.lemonaid.notification-watcher.plist`
+2. Starts the watcher daemon
+3. Prompts for Accessibility permissions if needed
+
+### 3. Grant Accessibility permissions
+
+The watcher needs Accessibility permissions to read Notification Center. macOS should prompt you automatically, but if not:
+
+1. Open System Settings > Privacy & Security > Accessibility
+2. Click the '+' button
+3. Navigate to your Python executable (shown in the install output)
+4. Ensure the checkbox is enabled
+
+To open System Settings directly:
+```bash
+open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
+```
+
+Verify permissions are working:
+```bash
+lemonaid macos logs -f
+```
+
+You should see "Watcher started. Listening for notifications..."
+
+## How it works
+
+1. A LaunchAgent daemon watches macOS Notification Center using the Accessibility API
+2. When a notification appears, the daemon extracts app name, title, subtitle, and body
+3. The daemon calls `lemonaid macos notify` with the notification details
+4. Lemonaid filters (currently Slack only) and adds matching notifications to the inbox
+
+### Deduplication
+
+Each macOS notification has a unique accessibility ID (`ax_id`). When you mark a notification as read in lemonaid, that `ax_id` is recorded. If macOS re-fires the same notification (e.g., when Notification Center refreshes), lemonaid skips it.
+
+## CLI commands
+
+```bash
+# Install watcher daemon
+lemonaid macos install-watcher
+
+# Uninstall watcher daemon
+lemonaid macos uninstall-watcher
+
+# Check watcher status
+lemonaid macos status
+
+# View watcher logs
+lemonaid macos logs
+lemonaid macos logs -f          # follow (like tail -f)
+lemonaid macos logs -n 50       # show 50 lines
+
+# Handle notification (called by daemon, not typically used directly)
+lemonaid macos notify --app <bundle_id> --title "..." --body "..." --ax-id "..."
+```
+
+## Slack Integration
+
+Slack integration is **opt-in** - without configuration, Slack notifications are silently ignored.
+
+### Quick setup
+
+1. **Enable Slack integration** by adding to `~/.config/lemonaid/config.toml`:
+   ```toml
+   [slack]
+   # That's it! Just having this section enables Slack integration.
+
+   # Optional: block specific channels/DMs from appearing in inbox
+   blocklist = [
+     "#announcements",
+     "#social-general",
+     "Slackbot",
+   ]
+   ```
+
+2. **Generate channel ID mappings** (see below)
+
+### Generating mappings
+
+Lemonaid needs channel/user IDs to construct `slack://` deep links. Unfortunately, Slack doesn't make this easy - you need to export the data from the browser.
+
+**For each workspace:**
+
+1. Open Slack in a web browser (not the desktop app)
+2. Open DevTools (F12) → **Application** → **IndexedDB**
+3. Expand **reduxPersistence** → **reduxPersistenceStore**
+4. Find the row with key like `persist:slack-client-...`
+5. Click on it, then right-click the **Value** preview and select "Copy object"
+6. Save to a file (e.g., `slack-export.json`)
+
+Then extract the mappings with jq:
+
+```bash
+# Get team ID (starts with T)
+TEAM_ID=$(jq -r '.teams | keys[] | select(startswith("T"))' slack-export.json)
+
+# Get workspace name for the JSON key
+WORKSPACE_NAME="My Workspace"  # Use the actual name shown in Slack
+
+# Extract channels and DMs, build mappings file
+jq -n \
+  --arg ws "$WORKSPACE_NAME" \
+  --arg team "$TEAM_ID" \
+  --slurpfile data slack-export.json '
+{
+  ($ws): {
+    "team_id": $team,
+    "channels": ([$data[0].channels | to_entries[] | select(.value.is_channel == true) | {key: ("#" + .value.name), value: .key}] | from_entries),
+    "dms": ([$data[0].channels | to_entries[] | select(.value.is_im == true) | {key: ($data[0].members[.value.user].real_name // .value.user), value: .key}] | from_entries)
+  }
+}' > /tmp/slack-workspace.json
+
+# For first workspace, or to overwrite:
+mv /tmp/slack-workspace.json ~/.local/state/lemonaid/slack-mappings.json
+
+# For additional workspaces, merge into existing file:
+jq -s '.[0] * .[1]' ~/.local/state/lemonaid/slack-mappings.json /tmp/slack-workspace.json > /tmp/merged.json \
+  && mv /tmp/merged.json ~/.local/state/lemonaid/slack-mappings.json
+```
+
+**Multiple workspaces:** Repeat the browser export and jq extraction for each workspace, using the merge command to combine them.
+
+### How it works
+
+1. macOS watcher captures Slack notifications (workspace name, channel, message)
+2. When you select a notification, lemonaid looks up the channel ID in cached mappings
+3. Opens `slack://channel?team=...&id=...` to go directly to the conversation
+4. If lookup fails, falls back to just opening Slack
+
+### Viewing mappings
+
+```bash
+lemonaid slack show-mappings              # show all
+lemonaid slack show-mappings -w "My Team" # show specific workspace
+lemonaid slack path                       # show mappings file path
+```
+
+Mappings are stored in `~/.local/state/lemonaid/slack-mappings.json`.
+
+### Disabling Slack integration
+
+Remove or comment out the `[slack]` section in your config. Slack notifications will be ignored until re-enabled.
+
+## Log locations
+
+- stdout: `~/.local/state/lemonaid/logs/watcher.log`
+- stderr: `~/.local/state/lemonaid/logs/watcher.err`
+
+## Troubleshooting
+
+### Watcher not starting
+
+```bash
+# Check status
+lemonaid macos status
+
+# View error log
+cat ~/.local/state/lemonaid/logs/watcher.err
+```
+
+### "Accessibility permission not granted"
+
+1. Open System Settings > Privacy & Security > Accessibility
+2. Add the Python executable shown in the error log
+3. Restart the watcher:
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.lemonaid.notification-watcher.plist
+   launchctl load ~/Library/LaunchAgents/com.lemonaid.notification-watcher.plist
+   ```
+
+### Notifications not appearing in inbox
+
+1. **Check watcher logs**: `lemonaid macos logs -f`
+2. **Verify it's Slack**: Only Slack notifications are currently captured
+3. **Check for "No notification banners found"**: The watcher filters out widgets (Weather, Calendar, etc.)
+
+### Same notification keeps appearing
+
+This shouldn't happen if deduplication is working. Check:
+```bash
+# See ax_id in notification metadata
+sqlite3 ~/.local/share/lemonaid/lemonaid.db \
+  "SELECT id, channel, status, json_extract(metadata, '$.ax_id') FROM notifications WHERE channel LIKE 'slack:%'"
+```
+
+## Architecture
+
+The design separates concerns:
+
+- **Watcher daemon** (`watcher.py`): "Dumb" - just watches Notification Center and calls `lemonaid macos notify`. Rarely needs updates.
+- **Notification handler** (`notify.py`): "Smart" - filters apps, deduplicates, adds to inbox. All logic lives here.
+- **LaunchAgent** (`launchd.py`): Manages daemon lifecycle via macOS launchctl.
+
+This means the daemon can stay running even as you update lemonaid - the smart logic is in the CLI command it calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,18 @@
 [project]
 name = "lemonaid"
-version = "0.5.0"
+version = "0.6.0"
 description = "Attention inbox for managing notifications from LLMs and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "textual>=0.89.0",
+]
+
+[project.optional-dependencies]
+# Requires macOS with Accessibility permissions granted
+macos = [
+    "pyobjc-framework-Quartz>=12.0",
+    "pyobjc-framework-ApplicationServices>=12.0",
 ]
 
 [dependency-groups]

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -34,6 +34,7 @@ from ..lemon_watchers import (
     get_tty,
     shorten_path,
 )
+from ..paths import get_log_path
 
 
 def get_session_name(session_id: str, cwd: str) -> str | None:
@@ -96,7 +97,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
     """
     import time
 
-    log_file = "/tmp/lemonaid-notify.log"
+    log_file = get_log_path("claude-notify")
 
     if stdin_data is None:
         stdin_data = sys.stdin.read()
@@ -209,7 +210,7 @@ def handle_dismiss(debug: bool = False) -> None:
     import time
 
     debug = debug or os.environ.get("LEMONAID_DEBUG") == "1"
-    log_file = "/tmp/lemonaid-dismiss.log"
+    log_file = get_log_path("claude-dismiss")
 
     stdin_raw = sys.stdin.read() or "{}"
 

--- a/src/lemonaid/cli.py
+++ b/src/lemonaid/cli.py
@@ -11,6 +11,9 @@ from .codex import cli as codex_cli
 from .config import ensure_config_exists, get_config_path
 from .inbox import cli as inbox_cli
 from .inbox import db as inbox_db
+from .macos import cli as macos_cli
+from .paths import get_log_path
+from .slack import cli as slack_cli
 from .tmux import cli as tmux_cli
 from .wezterm import cli as wezterm_cli
 
@@ -95,6 +98,8 @@ def main() -> None:
     inbox_cli.setup_parser(subparsers)
     claude_cli.setup_parser(subparsers)
     codex_cli.setup_parser(subparsers)
+    macos_cli.setup_parser(subparsers)
+    slack_cli.setup_parser(subparsers)
     tmux_cli.setup_parser(subparsers)
     wezterm_cli.setup_parser(subparsers)
     setup_config_parser(subparsers)
@@ -115,7 +120,7 @@ def main() -> None:
         import traceback
 
         # Log to file since Claude Code may hide stderr
-        with open("/tmp/lemonaid-errors.log", "a") as f:
+        with open(get_log_path("errors"), "a") as f:
             f.write(f"[{time.strftime('%H:%M:%S')}] {' '.join(sys.argv)}\n")
             f.write(traceback.format_exc())
             f.write("\n")

--- a/src/lemonaid/codex/notify.py
+++ b/src/lemonaid/codex/notify.py
@@ -14,6 +14,7 @@ from ..lemon_watchers import (
     get_tty,
     shorten_path,
 )
+from ..paths import get_log_path
 from .utils import (
     extract_session_id_from_filename,
     find_latest_session_for_cwd,
@@ -99,7 +100,7 @@ def handle_notification(
     """
     import time
 
-    log_file = "/tmp/lemonaid-codex-notify.log"
+    log_file = get_log_path("codex-notify")
 
     if stdin_data is None:
         stdin_data = sys.stdin.read()
@@ -208,7 +209,7 @@ def handle_dismiss(debug: bool = False) -> None:
     import time
 
     debug = debug or os.environ.get("LEMONAID_DEBUG") == "1"
-    log_file = "/tmp/lemonaid-codex-dismiss.log"
+    log_file = get_log_path("codex-dismiss")
 
     stdin_raw = sys.stdin.read() or "{}"
 

--- a/src/lemonaid/codex/watcher.py
+++ b/src/lemonaid/codex/watcher.py
@@ -16,6 +16,7 @@ from .utils import get_sessions_root
 # Channel prefix for Codex notifications
 CHANNEL_PREFIX = "codex:"
 
+
 def get_session_path(session_id: str, cwd: str) -> Path | None:
     """Find a Codex session file by session ID.
 
@@ -69,14 +70,13 @@ def describe_activity(entry: dict) -> str | None:
         content = entry.get("content", [])
         if isinstance(content, list):
             for block in content:
-                if isinstance(block, dict):
-                    if block.get("type") in ("output_text", "text"):
-                        text = block.get("text", "")
-                        if text.strip():
-                            first_line = text.strip().split("\n")[0][:60]
-                            if len(first_line) < len(text.strip().split("\n")[0]):
-                                first_line += "..."
-                            return first_line
+                if isinstance(block, dict) and block.get("type") in ("output_text", "text"):
+                    text = block.get("text", "")
+                    if text.strip():
+                        first_line = text.strip().split("\n")[0][:60]
+                        if len(first_line) < len(text.strip().split("\n")[0]):
+                            first_line += "..."
+                        return first_line
 
     # response_item format
     if entry_type == "response_item":

--- a/src/lemonaid/lemon_watchers/watcher.py
+++ b/src/lemonaid/lemon_watchers/watcher.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
+from ..paths import get_log_path
+
 
 class WatcherBackend(Protocol):
     """Protocol for LLM-specific watcher backends."""
@@ -262,7 +264,7 @@ def unified_watch_loop(
         archive_channel: Optional callback to archive a channel when session exits
         poll_interval: How often to poll (seconds)
     """
-    log_file = Path("/tmp/lemonaid-watcher.log")
+    log_file = get_log_path("session-watcher")
 
     def log(msg: str):
         with open(log_file, "a") as f:

--- a/src/lemonaid/macos/__init__.py
+++ b/src/lemonaid/macos/__init__.py
@@ -1,0 +1,8 @@
+"""macOS notification integration.
+
+This module provides integration with macOS Notification Center, allowing
+lemonaid to capture notifications from any app (Slack, etc.) and present
+them in the unified inbox.
+
+Requires the [macos] extra: pip install lemonaid[macos]
+"""

--- a/src/lemonaid/macos/cli.py
+++ b/src/lemonaid/macos/cli.py
@@ -1,0 +1,155 @@
+"""CLI commands for macOS notification integration."""
+
+import argparse
+import sys
+
+
+def _check_macos_deps() -> bool:
+    """Check if macOS dependencies are installed."""
+    try:
+        import ApplicationServices  # noqa: F401
+        import Quartz  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _require_macos_deps() -> None:
+    """Exit with helpful message if macOS deps not installed."""
+    if not _check_macos_deps():
+        print("macOS notification support requires additional dependencies.", file=sys.stderr)
+        print("Install with: pip install lemonaid[macos]", file=sys.stderr)
+        print("         or: uv pip install lemonaid[macos]", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_notify(args: argparse.Namespace) -> None:
+    """Handle a notification from the macOS watcher daemon."""
+    from .notify import handle_notification
+
+    handle_notification(
+        app_bundle_id=args.app,
+        title=args.title,
+        body=args.body,
+        workspace=args.workspace or None,
+        ax_id=args.ax_id or None,
+    )
+
+
+def cmd_install_watcher(args: argparse.Namespace) -> None:
+    """Install and start the macOS notification watcher daemon."""
+    _require_macos_deps()
+    from .launchd import install_watcher
+
+    install_watcher(start=not args.no_start)
+
+
+def cmd_uninstall_watcher(args: argparse.Namespace) -> None:
+    """Stop and uninstall the macOS notification watcher daemon."""
+    from .launchd import uninstall_watcher
+
+    uninstall_watcher()
+
+
+def cmd_watcher_status(args: argparse.Namespace) -> None:
+    """Check status of the macOS notification watcher daemon."""
+    from .launchd import watcher_status
+
+    watcher_status()
+
+
+def cmd_watcher_logs(args: argparse.Namespace) -> None:
+    """Show recent logs from the macOS notification watcher daemon."""
+    from .launchd import watcher_logs
+
+    watcher_logs(lines=args.lines, follow=args.follow)
+
+
+def setup_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Set up the macos subcommand."""
+    macos_parser = subparsers.add_parser(
+        "macos",
+        help="macOS Notification Center integration",
+    )
+    macos_subparsers = macos_parser.add_subparsers(dest="macos_command")
+
+    # macos notify - called by the watcher daemon
+    notify_parser = macos_subparsers.add_parser(
+        "notify",
+        help="Handle notification from watcher daemon (internal use)",
+    )
+    notify_parser.add_argument(
+        "--app",
+        required=True,
+        help="App bundle ID (e.g., com.tinyspeck.slackmacgap)",
+    )
+    notify_parser.add_argument(
+        "--title",
+        required=True,
+        help="Notification title",
+    )
+    notify_parser.add_argument(
+        "--body",
+        default="",
+        help="Notification body text",
+    )
+    notify_parser.add_argument(
+        "--workspace",
+        default="",
+        help="Slack workspace name (for multi-workspace deep linking)",
+    )
+    notify_parser.add_argument(
+        "--ax-id",
+        default="",
+        help="macOS accessibility identifier (for deduplication)",
+    )
+    notify_parser.set_defaults(func=cmd_notify)
+
+    # macos install-watcher
+    install_parser = macos_subparsers.add_parser(
+        "install-watcher",
+        help="Install the notification watcher daemon (LaunchAgent)",
+    )
+    install_parser.add_argument(
+        "--no-start",
+        action="store_true",
+        help="Install but don't start the watcher",
+    )
+    install_parser.set_defaults(func=cmd_install_watcher)
+
+    # macos uninstall-watcher
+    uninstall_parser = macos_subparsers.add_parser(
+        "uninstall-watcher",
+        help="Stop and uninstall the notification watcher daemon",
+    )
+    uninstall_parser.set_defaults(func=cmd_uninstall_watcher)
+
+    # macos status
+    status_parser = macos_subparsers.add_parser(
+        "status",
+        help="Check watcher daemon status",
+    )
+    status_parser.set_defaults(func=cmd_watcher_status)
+
+    # macos logs
+    logs_parser = macos_subparsers.add_parser(
+        "logs",
+        help="Show watcher daemon logs",
+    )
+    logs_parser.add_argument(
+        "-n",
+        "--lines",
+        type=int,
+        default=20,
+        help="Number of lines to show (default: 20)",
+    )
+    logs_parser.add_argument(
+        "-f",
+        "--follow",
+        action="store_true",
+        help="Follow log output (like tail -f)",
+    )
+    logs_parser.set_defaults(func=cmd_watcher_logs)
+
+    macos_parser.set_defaults(func=lambda a: macos_parser.print_help())

--- a/src/lemonaid/macos/launchd.py
+++ b/src/lemonaid/macos/launchd.py
@@ -1,0 +1,226 @@
+"""LaunchAgent management for the macOS notification watcher daemon."""
+
+import contextlib
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+LABEL = "com.lemonaid.notification-watcher"
+PLIST_NAME = f"{LABEL}.plist"
+
+
+def _get_launch_agents_dir() -> Path:
+    """Get the user's LaunchAgents directory."""
+    return Path.home() / "Library" / "LaunchAgents"
+
+
+def _get_plist_path() -> Path:
+    """Get the path to our LaunchAgent plist."""
+    return _get_launch_agents_dir() / PLIST_NAME
+
+
+def _get_log_dir() -> Path:
+    """Get the directory for watcher logs."""
+    from ..paths import get_log_dir
+
+    return get_log_dir()
+
+
+def _get_lemonaid_executable() -> str:
+    """Get the path to the lemonaid executable."""
+    # First try to find it in the same environment as this process
+    lemonaid_path = shutil.which("lemonaid")
+    if lemonaid_path:
+        return lemonaid_path
+
+    # Fall back to assuming it's installed via uv tool
+    uv_bin = Path.home() / ".local" / "bin" / "lemonaid"
+    if uv_bin.exists():
+        return str(uv_bin)
+
+    # Last resort: use the Python that's running this
+    return f"{sys.executable} -m lemonaid"
+
+
+def _get_watcher_script_path() -> Path:
+    """Get the path to the watcher script."""
+    # The watcher module is part of the lemonaid package
+    return Path(__file__).parent / "watcher.py"
+
+
+def _generate_plist() -> dict:
+    """Generate the LaunchAgent plist configuration."""
+    log_dir = _get_log_dir()
+
+    # We run the watcher as a Python script using the same interpreter
+    # that's running lemonaid
+    watcher_script = _get_watcher_script_path()
+    lemonaid_exec = _get_lemonaid_executable()
+
+    return {
+        "Label": LABEL,
+        "ProgramArguments": [sys.executable, str(watcher_script), "--lemonaid", lemonaid_exec],
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "StandardOutPath": str(log_dir / "watcher.log"),
+        "StandardErrorPath": str(log_dir / "watcher.err"),
+        "EnvironmentVariables": {
+            # Pass through PATH so the watcher can find lemonaid
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        },
+    }
+
+
+def install_watcher(start: bool = True) -> None:
+    """Install the notification watcher as a LaunchAgent.
+
+    Args:
+        start: Whether to start the watcher after installing
+    """
+    plist_path = _get_plist_path()
+    launch_agents_dir = _get_launch_agents_dir()
+
+    # Ensure LaunchAgents directory exists
+    launch_agents_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stop existing watcher if running
+    if plist_path.exists():
+        print("Stopping existing watcher...")
+        subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+
+    # Write plist
+    plist_data = _generate_plist()
+    with open(plist_path, "wb") as f:
+        plistlib.dump(plist_data, f)
+    print(f"Installed LaunchAgent: {plist_path}")
+
+    # Show where logs will go
+    log_dir = _get_log_dir()
+    print(f"Logs will be written to: {log_dir}")
+
+    if start:
+        result = subprocess.run(["launchctl", "load", str(plist_path)], capture_output=True)
+        if result.returncode == 0:
+            print("Watcher started successfully")
+            _print_accessibility_instructions()
+        else:
+            print(f"Failed to start watcher: {result.stderr.decode()}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("Watcher installed but not started. Run 'launchctl load' to start:")
+        print(f"  launchctl load {plist_path}")
+
+
+def _print_accessibility_instructions() -> None:
+    """Print clear instructions for granting Accessibility permissions."""
+    python_path = sys.executable
+
+    print()
+    print("=" * 60)
+    print("ACCESSIBILITY PERMISSIONS REQUIRED")
+    print("=" * 60)
+    print()
+    print("The watcher needs Accessibility permissions to read notifications.")
+    print("macOS should prompt you automatically, but if not:")
+    print()
+    print("1. Open System Settings > Privacy & Security > Accessibility")
+    print("2. Click the '+' button")
+    print(f"3. Navigate to and add: {python_path}")
+    print("4. Ensure the checkbox next to it is enabled")
+    print()
+    print("To verify permissions are working:")
+    print("  lemonaid macos logs -f")
+    print()
+    print("You should see 'Watcher started. Listening for notifications...'")
+    print("If you see 'Accessibility permission not granted', add the path above.")
+    print()
+    print("To open System Settings now, run:")
+    print("  open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'")
+    print("=" * 60)
+
+
+def uninstall_watcher() -> None:
+    """Stop and uninstall the notification watcher."""
+    plist_path = _get_plist_path()
+
+    if not plist_path.exists():
+        print("Watcher is not installed")
+        return
+
+    # Stop the watcher
+    result = subprocess.run(["launchctl", "unload", str(plist_path)], capture_output=True)
+    if result.returncode != 0:
+        print(f"Warning: Failed to stop watcher: {result.stderr.decode()}", file=sys.stderr)
+
+    # Remove the plist
+    plist_path.unlink()
+    print(f"Removed LaunchAgent: {plist_path}")
+    print("Watcher uninstalled")
+
+
+def watcher_status() -> None:
+    """Check the status of the notification watcher daemon."""
+    plist_path = _get_plist_path()
+
+    if not plist_path.exists():
+        print("Watcher is not installed")
+        print("Run 'lemonaid macos install-watcher' to install")
+        return
+
+    # Check if it's running via launchctl
+    result = subprocess.run(["launchctl", "list", LABEL], capture_output=True, text=True)
+
+    if result.returncode == 0:
+        # Parse the output to get PID and status
+        lines = result.stdout.strip().split("\n")
+        if len(lines) >= 1:
+            # Output format: PID\tStatus\tLabel
+            # or just info about the job
+            print(f"Watcher is installed: {plist_path}")
+            print(f"Status: {result.stdout.strip()}")
+    else:
+        print(f"Watcher is installed but not running: {plist_path}")
+        print("Start with: launchctl load", str(plist_path))
+
+    # Show log locations
+    log_dir = _get_log_dir()
+    print(f"\nLogs: {log_dir}")
+
+
+def watcher_logs(lines: int = 20, follow: bool = False) -> None:
+    """Show recent logs from the watcher daemon.
+
+    Args:
+        lines: Number of lines to show
+        follow: Whether to follow the log (like tail -f)
+    """
+    log_dir = _get_log_dir()
+    log_file = log_dir / "watcher.log"
+    err_file = log_dir / "watcher.err"
+
+    if not log_file.exists() and not err_file.exists():
+        print("No logs found. Is the watcher running?")
+        print(f"Expected logs at: {log_dir}")
+        return
+
+    if follow:
+        # Use tail -f on both log files
+        cmd = ["tail", "-f"]
+        if log_file.exists():
+            cmd.append(str(log_file))
+        if err_file.exists():
+            cmd.append(str(err_file))
+        with contextlib.suppress(KeyboardInterrupt):
+            subprocess.run(cmd)
+    else:
+        # Show recent lines from both files
+        if log_file.exists():
+            print(f"=== {log_file} ===")
+            subprocess.run(["tail", f"-{lines}", str(log_file)])
+
+        if err_file.exists():
+            print(f"\n=== {err_file} ===")
+            subprocess.run(["tail", f"-{lines}", str(err_file)])

--- a/src/lemonaid/macos/notify.py
+++ b/src/lemonaid/macos/notify.py
@@ -1,0 +1,107 @@
+"""macOS notification handler.
+
+This module handles notifications from the macOS notification watcher daemon,
+adding them to the lemonaid inbox.
+
+The watcher daemon calls:
+    lemonaid macos notify --app <bundle_id> --title "..." --body "..." --ax-id <uuid>
+
+Slack integration requires configuration. Without a mappings file configured,
+Slack notifications are silently ignored. This allows users to opt-in to
+Slack integration by providing the mappings file.
+"""
+
+from ..config import load_config
+from ..inbox import db
+
+SLACK_BUNDLE_ID = "com.tinyspeck.slackmacgap"
+
+
+def _get_slack_config():
+    """Get Slack config if enabled, else None."""
+    config = load_config()
+    # Slack is enabled if [slack] section exists in config
+    if config.slack.enabled:
+        return config.slack
+    return None
+
+
+def _is_already_seen_and_read(conn: db.sqlite3.Connection, ax_id: str) -> bool:
+    """Check if we've already processed this macOS notification and user marked it read.
+
+    Returns True if we should skip this notification (don't resurface it).
+    """
+    if not ax_id:
+        return False
+
+    # Look for any notification with this ax_id in metadata that's been read
+    row = conn.execute(
+        """
+        SELECT status FROM notifications
+        WHERE json_extract(metadata, '$.ax_id') = ?
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (ax_id,),
+    ).fetchone()
+
+    return bool(row and row["status"] == "read")
+
+
+def handle_notification(
+    app_bundle_id: str,
+    title: str,
+    body: str,
+    workspace: str | None = None,
+    ax_id: str | None = None,
+) -> None:
+    """Handle a notification from the macOS watcher daemon.
+
+    Args:
+        app_bundle_id: The bundle ID of the app that posted the notification
+        title: The notification title (often sender/channel name)
+        body: The notification body (message preview)
+        workspace: Workspace name (for Slack multi-workspace)
+        ax_id: macOS accessibility identifier for deduplication
+    """
+    if app_bundle_id != SLACK_BUNDLE_ID:
+        return
+
+    # Slack integration requires configuration - skip if not set up
+    slack_config = _get_slack_config()
+    if not slack_config:
+        return
+
+    # Check blocklist - title is the channel/DM name
+    if slack_config.is_blocked(title):
+        return
+
+    with db.connect() as conn:
+        # Check if we've already seen this notification and user marked it read
+        if ax_id and _is_already_seen_and_read(conn, ax_id):
+            return
+
+        # For Slack, title is usually the channel/DM name, body is the message
+        safe_title = title[:32].replace(":", "-").replace("/", "-") if title else "unknown"
+        channel = f"slack:{safe_title}"
+        name = title if title else "slack"
+        message = body if body else "New message"
+
+        metadata = {
+            "app_bundle_id": app_bundle_id,
+            "title": title,
+            "body": body,
+        }
+        if workspace:
+            metadata["workspace"] = workspace
+        if ax_id:
+            metadata["ax_id"] = ax_id
+
+        db.add(
+            conn,
+            channel=channel,
+            message=message,
+            name=name,
+            metadata=metadata,
+            switch_source="slack",
+        )

--- a/src/lemonaid/macos/watcher.py
+++ b/src/lemonaid/macos/watcher.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""macOS Notification Center watcher daemon.
+
+This script watches for notifications appearing in macOS Notification Center
+using the Accessibility API, then calls `lemonaid macos notify` to add them
+to the lemonaid inbox.
+
+Requires:
+- macOS
+- Accessibility permissions granted
+- pyobjc-framework-Quartz and pyobjc-framework-ApplicationServices
+
+Run as a daemon via LaunchAgent (see launchd.py) or directly for testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime
+from typing import Any
+
+# These imports will fail if PyObjC is not installed
+try:
+    import objc
+    from AppKit import NSWorkspace
+    from ApplicationServices import (
+        AXIsProcessTrustedWithOptions,
+        AXObserverAddNotification,
+        AXObserverCreate,
+        AXObserverGetRunLoopSource,
+        AXUIElementCopyAttributeValue,
+        AXUIElementCreateApplication,
+        kAXChildrenAttribute,
+        kAXDescriptionAttribute,
+        kAXSubroleAttribute,
+        kAXTrustedCheckOptionPrompt,
+        kAXValueAttribute,
+        kAXWindowCreatedNotification,
+    )
+    from Foundation import CFRunLoopAddSource, CFRunLoopGetCurrent, kCFRunLoopDefaultMode
+except ImportError as e:
+    print(f"Error: PyObjC not installed: {e}", file=sys.stderr)
+    print("Install with: pip install lemonaid[macos]", file=sys.stderr)
+    sys.exit(1)
+
+
+# Create the callback type for AXObserverCreate
+PAXObserverCallback = objc.callbackFor(AXObserverCreate)
+
+# Global state for the callback (callbacks can't be methods)
+_watcher_state: dict[str, Any] = {
+    "lemonaid_cmd": "lemonaid",
+    "last_notification_time": 0,
+    "debounce_seconds": 0.5,
+}
+
+
+def _log(msg: str) -> None:
+    """Log a message with timestamp."""
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def _find_notification_center_pid() -> int | None:
+    """Find the PID of the Notification Center process."""
+    workspace = NSWorkspace.sharedWorkspace()
+    for app in workspace.runningApplications():
+        if app.bundleIdentifier() == "com.apple.notificationcenterui":
+            return app.processIdentifier()
+
+    return None
+
+
+def _extract_notification_banner(element: Any) -> dict[str, Any] | None:
+    """Extract notification details from an AXNotificationCenterBanner element.
+
+    Returns dict with app_name, title, subtitle, body, ax_id if this is a real notification.
+    """
+    # Check if this is a notification banner (not a widget)
+    err, subrole = AXUIElementCopyAttributeValue(element, kAXSubroleAttribute, None)
+    if err != 0 or str(subrole) != "AXNotificationCenterBanner":
+        return None
+
+    # Get the description which contains: "AppName, Title, Subtitle, Body"
+    err, description = AXUIElementCopyAttributeValue(element, kAXDescriptionAttribute, None)
+    if err != 0 or not description:
+        return None
+
+    desc_str = str(description)
+    _log(f"  Found banner: {desc_str[:100]}...")
+
+    # Get the AXIdentifier (UUID) for deduplication
+    err, ax_identifier = AXUIElementCopyAttributeValue(element, "AXIdentifier", None)
+    ax_id = str(ax_identifier) if err == 0 and ax_identifier else None
+
+    # Debug: dump all attribute names and actions to find URL or click action
+    from ApplicationServices import AXUIElementCopyActionNames, AXUIElementCopyAttributeNames
+
+    err, attr_names = AXUIElementCopyAttributeNames(element, None)
+    if err == 0 and attr_names:
+        _log(f"  Banner attributes: {list(attr_names)}")
+        # Dump AXCustomActions - might contain URL or deep link info
+        err, custom_actions = AXUIElementCopyAttributeValue(element, "AXCustomActions", None)
+        _log(
+            f"  AXCustomActions err={err}, value={custom_actions}, type={type(custom_actions).__name__ if custom_actions else None}"
+        )
+        if err == 0 and custom_actions:
+            for i, action in enumerate(custom_actions):
+                _log(f"    Action {i}: {action} (type: {type(action).__name__})")
+                # Try to get action properties
+                if hasattr(action, "allKeys"):
+                    for key in action.allKeys():
+                        _log(f"      {key}: {action[key]}")
+
+    err, action_names = AXUIElementCopyActionNames(element, None)
+    if err == 0 and action_names:
+        _log(f"  Banner actions: {list(action_names)}")
+
+    # Parse description - first element is the app name
+    parts = desc_str.split(", ", 1)
+    app_name = parts[0] if parts else "unknown"
+
+    # Get the detailed fields from children (they have AXIdentifier: title, subtitle, body)
+    title = ""
+    subtitle = ""
+    body = ""
+
+    err, children = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute, None)
+    if err == 0 and children:
+        for child in children:
+            err, identifier = AXUIElementCopyAttributeValue(child, "AXIdentifier", None)
+            err2, value = AXUIElementCopyAttributeValue(child, kAXValueAttribute, None)
+            if err == 0 and err2 == 0 and identifier and value:
+                id_str = str(identifier)
+                val_str = str(value)
+                if id_str == "title":
+                    title = val_str
+                elif id_str == "subtitle":
+                    subtitle = val_str
+                elif id_str == "body":
+                    body = val_str
+
+    return {
+        "app_name": app_name,
+        "title": title,
+        "subtitle": subtitle,
+        "body": body,
+        "description": desc_str,
+        "ax_id": ax_id,
+    }
+
+
+def _find_notification_banners(window_element: Any) -> list[dict[str, Any]]:
+    """Traverse the notification center window to find notification banners.
+
+    Only returns actual notifications (AXNotificationCenterBanner), not widgets.
+    """
+    notifications = []
+
+    def traverse(element: Any, depth: int = 0) -> None:
+        if depth > 10:
+            return
+
+        # Check if this element is a notification banner
+        banner = _extract_notification_banner(element)
+        if banner:
+            notifications.append(banner)
+            return  # Don't traverse into banner children, we already extracted them
+
+        # Traverse children
+        err, children = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute, None)
+        if err == 0 and children:
+            for child in children:
+                traverse(child, depth + 1)
+
+    traverse(window_element)
+    return notifications
+
+
+def _send_notification(
+    lemonaid_cmd: str,
+    app_bundle_id: str,
+    title: str,
+    body: str,
+    workspace: str | None = None,
+    ax_id: str | None = None,
+) -> None:
+    """Send a notification to lemonaid."""
+    cmd = f"{lemonaid_cmd} macos notify --app {shlex.quote(app_bundle_id)} --title {shlex.quote(title)} --body {shlex.quote(body)}"
+    if workspace:
+        cmd += f" --workspace {shlex.quote(workspace)}"
+    if ax_id:
+        cmd += f" --ax-id {shlex.quote(ax_id)}"
+    _log(f"Calling: {cmd}")
+    try:
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=5)
+        if result.returncode != 0:
+            _log(f"Error from lemonaid: {result.stderr}")
+    except subprocess.TimeoutExpired:
+        _log("Timeout calling lemonaid")
+    except Exception as e:
+        _log(f"Exception calling lemonaid: {e}")
+
+
+@PAXObserverCallback
+def _observer_callback(observer: Any, element: Any, notification: Any, refcon: Any) -> None:
+    """Callback when a notification center event occurs."""
+    now = time.time()
+
+    # Debounce - notification center can fire multiple events quickly
+    if now - _watcher_state["last_notification_time"] < _watcher_state["debounce_seconds"]:
+        return
+
+    _watcher_state["last_notification_time"] = now
+
+    _log(f"Notification event: {notification}")
+
+    # Find actual notification banners (not widgets)
+    banners = _find_notification_banners(element)
+
+    for banner in banners:
+        app_name = banner["app_name"]
+        title = banner["title"]
+        subtitle = banner["subtitle"]
+        body = banner["body"]
+        ax_id = banner.get("ax_id")
+
+        _log(
+            f"  Notification from {app_name}: title={title}, subtitle={subtitle}, body={body[:50] if body else ''}..."
+        )
+
+        # Map app name to bundle ID for filtering (Slack → com.tinyspeck.slackmacgap)
+        bundle_id = "com.tinyspeck.slackmacgap" if app_name.lower() == "slack" else app_name.lower()
+
+        # For Slack: title=workspace, subtitle=channel, body=message
+        # Pass workspace separately for multi-workspace deep linking
+        workspace = title if app_name.lower() == "slack" else None
+        display_title = subtitle if subtitle else title  # Channel or sender name
+        display_body = body if body else ""
+
+        if display_title or display_body:
+            _send_notification(
+                _watcher_state["lemonaid_cmd"],
+                bundle_id,
+                display_title,
+                display_body,
+                workspace=workspace,
+                ax_id=ax_id,
+            )
+
+    if not banners:
+        _log("  No notification banners found (may be widgets only)")
+
+
+def start_watcher(lemonaid_cmd: str) -> None:
+    """Start watching for notifications."""
+    _watcher_state["lemonaid_cmd"] = lemonaid_cmd
+
+    _log("Starting notification watcher...")
+
+    trusted = AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: True})
+    if not trusted:
+        _log("Accessibility permission not granted. Please enable in System Settings.")
+        _log("System Settings > Privacy & Security > Accessibility")
+
+    nc_pid = _find_notification_center_pid()
+    if not nc_pid:
+        _log("ERROR: Could not find Notification Center process")
+        sys.exit(1)
+
+    _log(f"Found Notification Center PID: {nc_pid}")
+
+    nc_element = AXUIElementCreateApplication(nc_pid)
+
+    # Debug: scan existing windows/notifications on startup
+    _log("Scanning existing notifications...")
+    err, windows = AXUIElementCopyAttributeValue(nc_element, "AXWindows", None)
+    if err == 0 and windows:
+        _log(f"  Found {len(windows)} windows")
+        for window in windows:
+            banners = _find_notification_banners(window)
+            _log(f"  Window has {len(banners)} banners")
+    else:
+        _log("  No windows found (or error)")
+
+    err, observer = AXObserverCreate(nc_pid, _observer_callback, None)
+    if err != 0:
+        _log(f"ERROR: Failed to create observer (error {err})")
+        _log("This usually means accessibility permissions are not granted.")
+        sys.exit(1)
+
+    err = AXObserverAddNotification(observer, nc_element, kAXWindowCreatedNotification, None)
+    if err != 0:
+        _log(f"WARNING: Failed to add window created notification (error {err})")
+
+    run_loop_source = AXObserverGetRunLoopSource(observer)
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), run_loop_source, kCFRunLoopDefaultMode)
+
+    _log("Watcher started. Listening for notifications...")
+    _log(f"Will call: {lemonaid_cmd} macos notify ...")
+
+    try:
+        from Foundation import NSRunLoop
+
+        run_loop = NSRunLoop.currentRunLoop()
+        while True:
+            run_loop.runUntilDate_(
+                NSRunLoop.currentRunLoop().limitDateForMode_(kCFRunLoopDefaultMode)
+            )
+    except KeyboardInterrupt:
+        _log("Shutting down...")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Watch macOS Notification Center and forward to lemonaid"
+    )
+    parser.add_argument(
+        "--lemonaid",
+        default="lemonaid",
+        help="Path to lemonaid executable (default: lemonaid)",
+    )
+    args = parser.parse_args()
+
+    start_watcher(args.lemonaid)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lemonaid/paths.py
+++ b/src/lemonaid/paths.py
@@ -1,0 +1,25 @@
+"""Path utilities for lemonaid."""
+
+from pathlib import Path
+
+
+def get_log_dir() -> Path:
+    """Get the directory for lemonaid logs.
+
+    Uses XDG state directory: ~/.local/state/lemonaid/logs/
+    """
+    log_dir = Path.home() / ".local" / "state" / "lemonaid" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def get_log_path(name: str) -> Path:
+    """Get the path to a specific log file.
+
+    Args:
+        name: Log file name (e.g., "watcher", "claude-notify")
+
+    Returns:
+        Path to ~/.local/state/lemonaid/logs/{name}.log
+    """
+    return get_log_dir() / f"{name}.log"

--- a/src/lemonaid/slack/__init__.py
+++ b/src/lemonaid/slack/__init__.py
@@ -1,0 +1,12 @@
+"""Slack integration for lemonaid.
+
+Provides deep linking to Slack channels/DMs from macOS notifications.
+Requires a manually-generated mappings file with channel IDs.
+
+Mappings are stored in ~/.local/state/lemonaid/slack-mappings.json
+See docs/macos.md for instructions on generating them.
+"""
+
+from .mappings import ChannelLookup, get_mappings_path, load_mappings, lookup_channel
+
+__all__ = ["ChannelLookup", "get_mappings_path", "load_mappings", "lookup_channel"]

--- a/src/lemonaid/slack/cli.py
+++ b/src/lemonaid/slack/cli.py
@@ -1,0 +1,86 @@
+"""CLI commands for Slack integration."""
+
+from __future__ import annotations
+
+import argparse
+
+from .mappings import get_mappings_path, load_mappings
+
+
+def cmd_show_mappings(args: argparse.Namespace) -> None:
+    """Display current Slack ID mappings."""
+    mappings = load_mappings(args.path)
+
+    if not mappings:
+        print("No mappings found.")
+        print(f"Mappings file: {get_mappings_path()}")
+        print()
+        print("See docs/macos.md for instructions on generating mappings")
+        print("from Slack's browser IndexedDB.")
+        return
+
+    workspace_filter = args.workspace
+    if workspace_filter:
+        if workspace_filter not in mappings:
+            print(f"Workspace '{workspace_filter}' not found in mappings")
+            print(f"Available: {', '.join(mappings.keys())}")
+            return
+        mappings = {workspace_filter: mappings[workspace_filter]}
+
+    for ws_name, ws_data in mappings.items():
+        print(f"\n{ws_name}")
+        print(f"  Team ID: {ws_data.get('team_id', 'unknown')}")
+
+        channels = ws_data.get("channels", {})
+        print(f"  Channels ({len(channels)}):")
+        for name in sorted(channels.keys())[:10]:
+            print(f"    {name}")
+        if len(channels) > 10:
+            print(f"    ... and {len(channels) - 10} more")
+
+        dms = ws_data.get("dms", {})
+        print(f"  DMs ({len(dms)}):")
+        for name in sorted(dms.keys())[:10]:
+            print(f"    {name}")
+        if len(dms) > 10:
+            print(f"    ... and {len(dms) - 10} more")
+
+
+def cmd_path(args: argparse.Namespace) -> None:
+    """Print the mappings file path."""
+    print(get_mappings_path())
+
+
+def setup_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Set up the slack subcommand."""
+    slack_parser = subparsers.add_parser(
+        "slack",
+        help="Slack integration (view ID mappings for deep linking)",
+    )
+    slack_subparsers = slack_parser.add_subparsers(dest="slack_command")
+
+    # slack show-mappings
+    show_parser = slack_subparsers.add_parser(
+        "show-mappings",
+        help="Display current Slack ID mappings",
+    )
+    show_parser.add_argument(
+        "-p",
+        "--path",
+        help="Path to mappings file",
+    )
+    show_parser.add_argument(
+        "-w",
+        "--workspace",
+        help="Show only this workspace",
+    )
+    show_parser.set_defaults(func=cmd_show_mappings)
+
+    # slack path
+    path_parser = slack_subparsers.add_parser(
+        "path",
+        help="Print the mappings file path",
+    )
+    path_parser.set_defaults(func=cmd_path)
+
+    slack_parser.set_defaults(func=lambda a: slack_parser.print_help())

--- a/src/lemonaid/slack/mappings.py
+++ b/src/lemonaid/slack/mappings.py
@@ -1,0 +1,106 @@
+"""Slack ID mappings for deep linking.
+
+Manages a JSON file that maps workspace/channel/user names to Slack IDs.
+This enables constructing slack:// deep links from macOS notification data.
+
+File structure:
+{
+  "Workspace Name": {
+    "team_id": "T...",
+    "channels": { "#channel-name": "C..." },
+    "dms": { "User Name": "D..." }
+  }
+}
+
+Mappings must be generated manually from Slack's browser IndexedDB.
+See docs/macos.md for instructions.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ChannelLookup:
+    """Result of looking up a channel/DM."""
+
+    team_id: str
+    channel_id: str
+
+
+def _get_default_path() -> Path:
+    """Get the default path for the mappings file (in state folder)."""
+    return Path.home() / ".local" / "state" / "lemonaid" / "slack-mappings.json"
+
+
+def _resolve_path(path: Path | str | None) -> Path:
+    """Resolve path to an absolute Path, using default if None."""
+    return _get_default_path() if path is None else Path(path).expanduser()
+
+
+def load_mappings(path: Path | str | None = None) -> dict:
+    """Load mappings from file.
+
+    Returns empty dict if file doesn't exist.
+    """
+    resolved = _resolve_path(path)
+
+    if not resolved.exists():
+        return {}
+
+    try:
+        with open(resolved) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def get_mappings_path() -> Path:
+    """Get the path where mappings are stored."""
+    return _get_default_path()
+
+
+def lookup_channel(
+    mappings: dict,
+    workspace_name: str,
+    channel_name: str,
+) -> ChannelLookup | None:
+    """Look up channel ID from workspace and channel name.
+
+    Args:
+        mappings: Loaded mappings dict
+        workspace_name: Name of the workspace (from notification title)
+        channel_name: Channel or user name (from notification subtitle)
+
+    Returns:
+        ChannelLookup with team_id and channel_id, or None if not found
+    """
+    workspace = mappings.get(workspace_name)
+    if not workspace:
+        return None
+
+    team_id = workspace.get("team_id", "")
+    if not team_id:
+        return None
+
+    channels = workspace.get("channels", {})
+    dms = workspace.get("dms", {})
+
+    # Try channels (with and without # prefix)
+    channel_id = channels.get(channel_name)
+    if not channel_id and not channel_name.startswith("#"):
+        channel_id = channels.get(f"#{channel_name}")
+    if not channel_id and channel_name.startswith("#"):
+        channel_id = channels.get(channel_name[1:])
+
+    # Try DMs
+    if not channel_id:
+        channel_id = dms.get(channel_name)
+
+    if not channel_id:
+        return None
+
+    return ChannelLookup(team_id=team_id, channel_id=channel_id)


### PR DESCRIPTION
## Summary

- Add macOS Notification Center watcher daemon that captures Slack notifications via Accessibility API
- Add Slack deep linking - selecting a notification opens `slack://channel?team=...&id=...` directly to the conversation
- Add centralized log path management (`paths.py`)
- Slack notifications archive when deep link works, stay unread if no mapping found (so user can retry after adding mappings)

## Setup

```bash
# Install with macOS dependencies
uv tool install --editable ~/play/lemonaid \
  --with pyobjc-framework-Quartz \
  --with pyobjc-framework-ApplicationServices

# Install watcher daemon  
lemonaid macos install-watcher

# Enable Slack in config
echo '[slack]' >> ~/.config/lemonaid/config.toml
```

Channel ID mappings require manual browser export from Slack's IndexedDB. See `docs/macos.md` for instructions.

## Test plan

- [ ] Install watcher daemon with `lemonaid macos install-watcher`
- [ ] Verify watcher logs show notifications: `lemonaid macos logs -f`
- [ ] Trigger a Slack notification and verify it appears in `lma`
- [ ] Select notification - should open Slack (or deep link if mappings configured)
- [ ] Verify archive behavior: deep link → archives, no deep link → stays unread

🤖 Generated with [Claude Code](https://claude.ai/claude-code)