### PR TITLE
feat: add OpenClaw integration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 0.6.0 (2026-02-03)
+
+#### Added
+
+- **OpenClaw integration**: New watcher backend for [OpenClaw](https://openclaw.ai/) sessions. Detects turn completion via `stopReason: "stop"` in transcripts and marks notifications as needing attention. See `docs/openclaw.md` for setup.
+- **Mark unread support**: Watcher can now mark notifications as unread when an agent completes and is waiting for user input.
+
+#### Fixed
+
+- **Flip-flop prevention**: When marking a notification as unread, `created_at` is updated to the current time. This prevents the watcher from immediately marking it read again based on old transcript entries.
+
 # 0.5.0 (2026-01-26)
 
 #### Added

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -1,0 +1,123 @@
+# OpenClaw Integration
+
+Lemonaid supports [OpenClaw](https://openclaw.ai/), the open-source personal AI assistant.
+
+## How It Works
+
+1. **Session registration** - Register from within the TUI using `!lemonaid openclaw register`
+2. **Activity updates** - The watcher monitors the session and shows what OpenClaw is doing
+3. **Turn-complete detection** - When the agent finishes (`stopReason: "stop"`), notification is marked as needing attention
+4. **Auto-dismiss** - When you provide input, the notification is marked as read
+
+## Setup
+
+### Quick Start (Recommended)
+
+From within your OpenClaw TUI session, run:
+
+```
+!lemonaid openclaw register
+```
+
+This registers the current session with lemonaid and captures the TTY for tmux pane switching. You only need to do this once per session.
+
+**Why this works:** OpenClaw's `!` prefix runs shell commands as a child of the TUI process, which means the command inherits the TUI's terminal context (TTY). Gateway-based hooks can't capture this because they run in a separate process.
+
+### Hook-Based Registration (Optional)
+
+You can also set up a hook to auto-register new sessions, though this won't capture the TTY (uses cwd-based pane matching instead).
+
+Create `~/.openclaw/hooks/lemonaid-notify/HOOK.md`:
+
+```markdown
+---
+name: lemonaid-notify
+description: Register OpenClaw sessions with lemonaid inbox
+metadata:
+  openclaw:
+    emoji: "🍋"
+    events:
+      - agent:bootstrap
+---
+```
+
+Create `~/.openclaw/hooks/lemonaid-notify/handler.ts`:
+
+```typescript
+import { exec } from "child_process";
+import type { HookHandler } from "@openclaw/sdk";
+
+const handler: HookHandler = async (event) => {
+  const sessionId = event.context?.sessionKey || "";
+  const cwd = event.context?.workspace || process.cwd();
+  const cmd = `lemonaid openclaw notify --session-id "${sessionId}" --cwd "${cwd}"`;
+  exec(cmd, (error) => {
+    if (error) console.error("lemonaid notify failed:", error);
+  });
+};
+
+export default handler;
+```
+
+Enable with: `openclaw hooks enable lemonaid-notify`
+
+**Note:** Hook-based registration runs in the Gateway process, not the TUI, so it can't capture the TTY. Use `!lemonaid openclaw register` from the TUI after the hook creates the entry to add the TTY.
+
+## Session Storage
+
+OpenClaw stores sessions at:
+- **Sessions**: `~/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl`
+- **Index**: `~/.openclaw/agents/<agentId>/sessions/sessions.json`
+- **Config**: `~/.openclaw/openclaw.json`
+
+## CLI Commands
+
+```bash
+# Register current session (run from TUI with ! prefix)
+!lemonaid openclaw register
+
+# Manually add a notification
+lemonaid openclaw notify --session-id <id> --cwd /path/to/project
+
+# Mark a session as read
+lemonaid openclaw dismiss --session-id <id>
+```
+
+### Shell Alias
+
+OpenClaw's `!` commands run in `/bin/sh`, not your normal shell, so aliases won't work. Create a script instead:
+
+```bash
+mkdir -p ~/sw/bin && cat > ~/sw/bin/lreg << 'EOF'
+#!/bin/sh
+exec lemonaid openclaw register "$@"
+EOF
+chmod +x ~/sw/bin/lreg
+```
+
+Make sure `~/sw/bin` is in your PATH, then from OpenClaw TUI: `!lreg`
+
+## Troubleshooting
+
+### Sessions not appearing
+
+1. Check OpenClaw is storing sessions in `~/.openclaw/agents/`
+2. Verify session files exist with `ls ~/.openclaw/agents/*/sessions/*.jsonl`
+3. Check watcher logs: `tail -f /tmp/lemonaid-watcher.log`
+
+### Activity not updating
+
+The watcher reads the last 64KB of each session file. If sessions are very large, activity detection may lag.
+
+## Technical Notes
+
+- Channel format: `openclaw:<session_id_prefix>`
+- Entry types watched: `message`, `custom_message`, `compaction`
+- Dismissal triggers: user messages, assistant activity
+- Turn-complete detection: `stopReason: "stop"` in assistant messages marks notification as needing attention
+
+### TTY Detection
+
+OpenClaw TypeScript hooks run in a Node.js process that doesn't have a TTY directly attached. To enable tmux pane switching, lemonaid walks up the process tree to find an ancestor shell's TTY. This uses the `ps` command which works on both macOS and Linux.
+
+If TTY detection fails (e.g., very deep process nesting), lemonaid falls back to matching panes by working directory. This fallback may be ambiguous if multiple sessions share the same cwd.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lemonaid"
-version = "0.5.0"
-description = "Attention inbox for managing notifications from LLMs and other background tools"
+version = "0.6.0"
+description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/lemonaid/claude/watcher.py
+++ b/src/lemonaid/claude/watcher.py
@@ -89,6 +89,15 @@ def should_dismiss(entry: dict) -> bool:
     return False
 
 
+def needs_attention(entry: dict) -> bool:
+    """Check if an entry indicates the agent is waiting for user input.
+
+    For Claude, this is handled by the notification hooks (Stop, Notification),
+    so we always return False here - the watcher doesn't need to mark as unread.
+    """
+    return False
+
+
 def _describe_tool_use(block: dict) -> str:
     """Describe a tool_use block in human-readable form."""
     tool_name = block.get("name", "unknown")

--- a/src/lemonaid/cli.py
+++ b/src/lemonaid/cli.py
@@ -11,6 +11,7 @@ from .codex import cli as codex_cli
 from .config import ensure_config_exists, get_config_path
 from .inbox import cli as inbox_cli
 from .inbox import db as inbox_db
+from .openclaw import cli as openclaw_cli
 from .tmux import cli as tmux_cli
 from .wezterm import cli as wezterm_cli
 
@@ -95,6 +96,7 @@ def main() -> None:
     inbox_cli.setup_parser(subparsers)
     claude_cli.setup_parser(subparsers)
     codex_cli.setup_parser(subparsers)
+    openclaw_cli.setup_parser(subparsers)
     tmux_cli.setup_parser(subparsers)
     wezterm_cli.setup_parser(subparsers)
     setup_config_parser(subparsers)

--- a/src/lemonaid/codex/watcher.py
+++ b/src/lemonaid/codex/watcher.py
@@ -16,6 +16,7 @@ from .utils import get_sessions_root
 # Channel prefix for Codex notifications
 CHANNEL_PREFIX = "codex:"
 
+
 def get_session_path(session_id: str, cwd: str) -> Path | None:
     """Find a Codex session file by session ID.
 
@@ -69,14 +70,13 @@ def describe_activity(entry: dict) -> str | None:
         content = entry.get("content", [])
         if isinstance(content, list):
             for block in content:
-                if isinstance(block, dict):
-                    if block.get("type") in ("output_text", "text"):
-                        text = block.get("text", "")
-                        if text.strip():
-                            first_line = text.strip().split("\n")[0][:60]
-                            if len(first_line) < len(text.strip().split("\n")[0]):
-                                first_line += "..."
-                            return first_line
+                if isinstance(block, dict) and block.get("type") in ("output_text", "text"):
+                    text = block.get("text", "")
+                    if text.strip():
+                        first_line = text.strip().split("\n")[0][:60]
+                        if len(first_line) < len(text.strip().split("\n")[0]):
+                            first_line += "..."
+                        return first_line
 
     # response_item format
     if entry_type == "response_item":
@@ -133,6 +133,15 @@ def should_dismiss(entry: dict) -> bool:
             if role in ("assistant", "user"):
                 return True
 
+    return False
+
+
+def needs_attention(entry: dict) -> bool:
+    """Check if an entry indicates the agent is waiting for user input.
+
+    For Codex, this is handled by the notification hooks,
+    so we always return False here - the watcher doesn't need to mark as unread.
+    """
     return False
 
 

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -268,6 +268,27 @@ def mark_read(conn: sqlite3.Connection, notification_id: int) -> None:
     conn.commit()
 
 
+def mark_unread_for_channel(conn: sqlite3.Connection, channel: str) -> int:
+    """Mark all notifications for a channel as unread (needs attention).
+
+    Used when an agent finishes and is waiting for user input.
+    Also updates created_at to now, so that should_dismiss() only looks
+    at entries after this point (prevents flip-flopping).
+    Returns count of notifications marked as unread.
+    """
+    now = time.time()
+    cursor = conn.execute(
+        """
+        UPDATE notifications
+        SET status = 'unread', read_at = NULL, created_at = ?
+        WHERE channel = ? AND status = 'read'
+        """,
+        (now, channel),
+    )
+    conn.commit()
+    return cursor.rowcount
+
+
 def mark_all_read_for_channel(
     conn: sqlite3.Connection,
     channel: str,

--- a/src/lemonaid/openclaw/__init__.py
+++ b/src/lemonaid/openclaw/__init__.py
@@ -1,0 +1,8 @@
+"""Lemonaid OpenClaw integration.
+
+OpenClaw is an open-source personal AI assistant. Sessions are stored at:
+~/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl
+
+Session index is at:
+~/.openclaw/agents/<agentId>/sessions/sessions.json
+"""

--- a/src/lemonaid/openclaw/cli.py
+++ b/src/lemonaid/openclaw/cli.py
@@ -1,0 +1,112 @@
+"""CLI commands for OpenClaw integration."""
+
+import argparse
+
+from .notify import dismiss_session, handle_dismiss, handle_notification, handle_register
+
+
+def cmd_notify(args: argparse.Namespace) -> None:
+    """Handle OpenClaw notification hook."""
+    handle_notification(
+        stdin_data=args.payload,
+        session_id=args.session_id,
+        agent_id=args.agent_id,
+        session_path=args.session_path,
+        cwd=args.cwd,
+        name=args.name,
+        message=args.message,
+        notification_type=args.notification_type,
+    )
+
+
+def cmd_dismiss(args: argparse.Namespace) -> None:
+    """Handle OpenClaw dismiss hook (mark notification as read)."""
+    if args.session_id:
+        dismiss_session(args.session_id)
+    else:
+        handle_dismiss()
+
+
+def cmd_register(args: argparse.Namespace) -> None:
+    """Register current OpenClaw session with lemonaid (captures TTY)."""
+    success = handle_register(session_id=args.session_id, cwd=args.cwd)
+    if not success:
+        raise SystemExit(1)
+
+
+def setup_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Set up the openclaw subcommand."""
+    openclaw_parser = subparsers.add_parser(
+        "openclaw",
+        help="OpenClaw integration",
+    )
+    openclaw_subparsers = openclaw_parser.add_subparsers(dest="openclaw_command")
+
+    notify_parser = openclaw_subparsers.add_parser(
+        "notify",
+        help="Handle notification from OpenClaw hook (reads JSON from stdin)",
+    )
+    notify_parser.add_argument(
+        "payload",
+        nargs="?",
+        help="JSON payload from OpenClaw hook (passed as a single argument)",
+    )
+    notify_parser.add_argument(
+        "--session-id",
+        "-s",
+        help="Session ID to associate with the notification",
+    )
+    notify_parser.add_argument(
+        "--agent-id",
+        "-a",
+        help="Agent ID (if known)",
+    )
+    notify_parser.add_argument(
+        "--session-path",
+        help="Path to OpenClaw session jsonl file",
+    )
+    notify_parser.add_argument(
+        "--cwd",
+        help="Working directory for the session",
+    )
+    notify_parser.add_argument(
+        "--name",
+        help="Display name for the session",
+    )
+    notify_parser.add_argument(
+        "--message",
+        help="Notification message override",
+    )
+    notify_parser.add_argument(
+        "--notification-type",
+        help="Notification/event type",
+    )
+    notify_parser.set_defaults(func=cmd_notify)
+
+    dismiss_parser = openclaw_subparsers.add_parser(
+        "dismiss",
+        help="Mark session's notification as read (reads JSON from stdin)",
+    )
+    dismiss_parser.add_argument(
+        "--session-id",
+        "-s",
+        help="Session ID to dismiss (if not provided, reads from stdin)",
+    )
+    dismiss_parser.set_defaults(func=cmd_dismiss)
+
+    register_parser = openclaw_subparsers.add_parser(
+        "register",
+        help="Register session with lemonaid (run from TUI: !lemonaid openclaw register)",
+    )
+    register_parser.add_argument(
+        "--session-id",
+        "-s",
+        help="Session ID to register (default: most recently modified session)",
+    )
+    register_parser.add_argument(
+        "--cwd",
+        help="Override cwd (default: use session's cwd from header)",
+    )
+    register_parser.set_defaults(func=cmd_register)
+
+    openclaw_parser.set_defaults(func=lambda a: openclaw_parser.print_help())

--- a/src/lemonaid/openclaw/notify.py
+++ b/src/lemonaid/openclaw/notify.py
@@ -1,0 +1,344 @@
+"""OpenClaw notification hook handler.
+
+OpenClaw may not have explicit notification hooks like Claude Code, but
+this module provides the handler infrastructure in case hooks are added
+or for manual triggering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from ..inbox import db
+from ..lemon_watchers import detect_terminal_switch_source, get_name_from_cwd, get_tty, shorten_path
+from .utils import (
+    extract_session_id_from_filename,
+    find_most_recent_session,
+    find_session_path,
+    get_last_user_message,
+    get_session_name,
+    read_session_header,
+)
+
+
+def _extract_session_id(data: dict, session_path: Path | None) -> str | None:
+    """Extract session ID from data or session path."""
+    for key in ("session_id", "sessionId", "id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    if session_path:
+        session_id = extract_session_id_from_filename(session_path.name)
+        if session_id:
+            return session_id
+
+        header = read_session_header(session_path)
+        if header and isinstance(header.get("id"), str):
+            return header["id"]
+
+    return None
+
+
+def _resolve_session_path(
+    session_id: str | None, agent_id: str | None, session_path: str | None
+) -> Path | None:
+    """Resolve the session file path."""
+    if session_path:
+        path = Path(session_path).expanduser()
+        if path.exists():
+            return path
+
+    if session_id:
+        return find_session_path(session_id, agent_id)
+
+    return None
+
+
+def _resolve_cwd(cwd: str | None, session_path: Path | None) -> str | None:
+    """Resolve the working directory."""
+    if cwd:
+        return cwd
+
+    if session_path:
+        header = read_session_header(session_path)
+        if header:
+            return header.get("cwd")
+
+    return None
+
+
+def handle_notification(
+    stdin_data: str | None = None,
+    *,
+    session_id: str | None = None,
+    agent_id: str | None = None,
+    session_path: str | None = None,
+    cwd: str | None = None,
+    name: str | None = None,
+    message: str | None = None,
+    notification_type: str | None = None,
+) -> None:
+    """Handle an OpenClaw notification.
+
+    Can be triggered by a hook or manually. Reads JSON from stdin
+    and adds a notification to the lemonaid inbox.
+    """
+    import time
+
+    log_file = "/tmp/lemonaid-openclaw-notify.log"
+
+    if stdin_data is None:
+        stdin_data = sys.stdin.read() if not sys.stdin.isatty() else ""
+
+    with open(log_file, "a") as f:
+        f.write(f"[{time.strftime('%H:%M:%S')}] stdin: {stdin_data[:200]}\n")
+
+    try:
+        data = json.loads(stdin_data) if stdin_data else {}
+    except json.JSONDecodeError:
+        data = {}
+
+    agent_id = agent_id or data.get("agent_id") or data.get("agentId")
+    session_path_obj = _resolve_session_path(session_id, agent_id, session_path)
+    session_id = session_id or _extract_session_id(data, session_path_obj)
+    cwd = _resolve_cwd(cwd or data.get("cwd"), session_path_obj)
+    notification_type = (
+        notification_type
+        or data.get("notification_type")
+        or data.get("event")
+        or data.get("type")
+        or "idle"
+    )
+
+    if not message:
+        short_path = shorten_path(cwd or "")
+        if notification_type == "idle":
+            message = f"Waiting in {short_path}"
+        elif "approval" in notification_type or "permission" in notification_type:
+            message = f"Permission needed in {short_path}"
+        else:
+            message = f"{notification_type} in {short_path}"
+
+    if not name:
+        name = data.get("name") or data.get("title") or get_name_from_cwd(cwd or "")
+
+    switch_source = detect_terminal_switch_source()
+
+    metadata: dict[str, str] = {}
+    if cwd:
+        metadata["cwd"] = cwd
+    if session_id:
+        metadata["session_id"] = session_id
+    if agent_id:
+        metadata["agent_id"] = agent_id
+    if notification_type:
+        metadata["notification_type"] = notification_type
+    if session_path_obj:
+        metadata["session_path"] = str(session_path_obj)
+
+    tty = get_tty()
+    if tty:
+        metadata["tty"] = tty
+
+    # Channel format: openclaw:<session_id_prefix>
+    channel = f"openclaw:{session_id[:8]}" if session_id else "openclaw:unknown"
+
+    with db.connect() as conn:
+        db.add(
+            conn,
+            channel=channel,
+            message=message,
+            name=name,
+            metadata=metadata,
+            switch_source=switch_source if switch_source != "unknown" else None,
+        )
+
+    with open(log_file, "a") as f:
+        f.write(
+            f"[{time.strftime('%H:%M:%S')}] added: channel={channel}, type={notification_type}\n"
+        )
+
+
+def dismiss_session(session_id: str, debug: bool = False) -> int:
+    """Dismiss (mark as read) the notification for an OpenClaw session."""
+    if not session_id:
+        if debug:
+            print("[dismiss] no session_id provided", file=sys.stderr)
+        return 0
+
+    channel = f"openclaw:{session_id[:8]}"
+    with db.connect() as conn:
+        count = db.mark_all_read_for_channel(conn, channel)
+        if debug:
+            print(
+                f"[dismiss] marked {count} notification(s) as read for {channel}", file=sys.stderr
+            )
+        return count
+
+
+def handle_dismiss(debug: bool = False) -> None:
+    """Dismiss (mark as read) the notification for this OpenClaw session."""
+    import time
+
+    if debug or os.environ.get("LEMONAID_DEBUG") == "1":
+        log_file = "/tmp/lemonaid-openclaw-dismiss.log"
+    else:
+        log_file = None
+
+    stdin_raw = (sys.stdin.read() if not sys.stdin.isatty() else "{}") or "{}"
+
+    if log_file:
+        with open(log_file, "a") as f:
+            f.write(f"[{time.strftime('%H:%M:%S')}] stdin: {stdin_raw[:100]}\n")
+
+    try:
+        data = json.loads(stdin_raw)
+    except json.JSONDecodeError:
+        data = {}
+
+    session_id = _extract_session_id(data, None)
+    count = dismiss_session(session_id or "", debug=debug)
+
+    if log_file:
+        with open(log_file, "a") as f:
+            f.write(
+                f"[{time.strftime('%H:%M:%S')}] session_id={session_id[:8] if session_id else 'NONE'}, marked={count}\n"
+            )
+
+
+def handle_register(session_id: str | None = None, cwd: str | None = None) -> bool:
+    """Register/update an OpenClaw session with the current TTY.
+
+    Designed to be run from within OpenClaw's TUI via the ! prefix:
+        !lemonaid openclaw register
+
+    If session_id is provided, registers that specific session.
+    Otherwise, finds the most recently modified session.
+
+    Returns True if successful, False otherwise.
+    """
+    import time
+
+    log_file = "/tmp/lemonaid-openclaw-register.log"
+
+    # Get TTY - should inherit from TUI process
+    tty = get_tty()
+
+    with open(log_file, "a") as f:
+        f.write(f"[{time.strftime('%H:%M:%S')}] register: session_id={session_id}, tty={tty}\n")
+
+    if not tty:
+        print("Warning: Could not detect TTY. Notification will use cwd-based matching.")
+
+    # Find session - either by ID or most recent
+    if session_id:
+        session_path = find_session_path(session_id)
+        if session_path:
+            header = read_session_header(session_path)
+            agent_id = session_path.parent.parent.name if session_path else None
+            session_cwd = header.get("cwd") if header else None
+        else:
+            session_path, agent_id, session_cwd = None, None, None
+    else:
+        session_path, session_id, agent_id, session_cwd = find_most_recent_session()
+
+    if not session_path or not session_id:
+        if session_id:
+            print(f"Session not found: {session_id}")
+        else:
+            print("No OpenClaw session found")
+        with open(log_file, "a") as f:
+            f.write(f"[{time.strftime('%H:%M:%S')}] no session found\n")
+        return False
+
+    with open(log_file, "a") as f:
+        f.write(
+            f"[{time.strftime('%H:%M:%S')}] found session: {session_id[:8]}, "
+            f"agent={agent_id}, cwd={session_cwd}\n"
+        )
+
+    # Use session's cwd (from header), not the TUI's working directory
+    cwd = session_cwd or cwd or os.getcwd()
+
+    # Build metadata
+    switch_source = detect_terminal_switch_source()
+    # Get session name: label > session key segment > cwd folder name
+    name = None
+    if agent_id:
+        name = get_session_name(agent_id, session_id)
+    if not name:
+        name = get_name_from_cwd(cwd)
+    short_path = shorten_path(cwd)
+    message = f"Registered in {short_path}"
+
+    metadata: dict[str, str] = {
+        "cwd": cwd,
+        "session_id": session_id,
+        "session_path": str(session_path),
+    }
+    if agent_id:
+        metadata["agent_id"] = agent_id
+    if tty:
+        metadata["tty"] = tty
+
+    channel = f"openclaw:{session_id[:8]}"
+
+    # Upsert the notification
+    with db.connect() as conn:
+        existing = db.get_by_channel(conn, channel, unread_only=False)
+
+        if existing:
+            # Update existing - preserve message but update TTY
+            new_metadata = {**existing.metadata, **metadata}
+            # Keep the existing message unless it's the default "Registered" message
+            if not existing.message.startswith("Registered"):
+                message = existing.message
+
+            db.add(
+                conn,
+                channel=channel,
+                message=message,
+                name=existing.name or name,
+                metadata=new_metadata,
+                switch_source=switch_source
+                if switch_source != "unknown"
+                else existing.switch_source,
+            )
+            action = "updated"
+        else:
+            db.add(
+                conn,
+                channel=channel,
+                message=message,
+                name=name,
+                metadata=metadata,
+                switch_source=switch_source if switch_source != "unknown" else None,
+            )
+            action = "created"
+
+    # Get session info for confirmation
+    session_name = None
+    if agent_id:
+        session_name = get_session_name(agent_id, session_id)
+    last_message = get_last_user_message(session_path)
+
+    # Print confirmation with enough info to verify correct session
+    tty_display = tty.replace("/dev/", "") if tty else "none"
+    print(f"Registered most recent session (tty: {tty_display})")
+    print(f"  Channel: {channel}")
+    print(f"  Cwd: {cwd}")
+    if session_name:
+        print(f"  Name: {session_name}")
+    if last_message:
+        print(f"  Last input: {last_message}")
+    print()
+    print("If this is the wrong session, use: lemonaid openclaw register --session-id <id>")
+
+    with open(log_file, "a") as f:
+        f.write(f"[{time.strftime('%H:%M:%S')}] {action}: {channel}, tty={tty}\n")
+
+    return True

--- a/src/lemonaid/openclaw/utils.py
+++ b/src/lemonaid/openclaw/utils.py
@@ -1,0 +1,353 @@
+"""OpenClaw session utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def get_agents_root() -> Path:
+    """Return the OpenClaw agents root directory."""
+    return Path.home() / ".openclaw" / "agents"
+
+
+def get_sessions_root(agent_id: str) -> Path:
+    """Return the sessions directory for an agent."""
+    return get_agents_root() / agent_id / "sessions"
+
+
+def extract_session_id_from_filename(name: str) -> str | None:
+    """Extract a session UUID from an OpenClaw session filename.
+
+    OpenClaw uses UUID-style session IDs like:
+    a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl
+    """
+    match = re.search(
+        r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        name,
+    )
+    if match:
+        return match.group(1)
+    return None
+
+
+def read_session_header(path: Path) -> dict | None:
+    """Read the session header from a session file.
+
+    OpenClaw session files have a header line with type: "session"
+    containing id, cwd, timestamp, and optional parentSession.
+    """
+    try:
+        with path.open() as f:
+            line = f.readline()
+            if not line:
+                return None
+
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                return None
+
+            if entry.get("type") == "session":
+                return entry
+    except OSError:
+        return None
+
+    return None
+
+
+def find_session_path(session_id: str, agent_id: str | None = None) -> Path | None:
+    """Find an OpenClaw session file by session ID.
+
+    If agent_id is provided, search only that agent's sessions.
+    Otherwise, search all agents.
+    """
+    if not session_id:
+        return None
+
+    agents_root = get_agents_root()
+    if not agents_root.exists():
+        return None
+
+    if agent_id:
+        # Search specific agent
+        sessions_dir = get_sessions_root(agent_id)
+        if sessions_dir.exists():
+            for path in sessions_dir.glob(f"*{session_id}.jsonl"):
+                if path.is_file():
+                    return path
+            # Try partial match
+            if len(session_id) >= 8:
+                for path in sessions_dir.glob("*.jsonl"):
+                    if session_id[:8] in path.name:
+                        return path
+    else:
+        # Search all agents
+        for agent_dir in agents_root.iterdir():
+            if not agent_dir.is_dir():
+                continue
+
+            sessions_dir = agent_dir / "sessions"
+            if not sessions_dir.exists():
+                continue
+
+            for path in sessions_dir.glob(f"*{session_id}.jsonl"):
+                if path.is_file():
+                    return path
+
+            # Try partial match
+            if len(session_id) >= 8:
+                for path in sessions_dir.glob("*.jsonl"):
+                    if session_id[:8] in path.name:
+                        return path
+
+    return None
+
+
+def discover_agents() -> list[str]:
+    """Discover all agent IDs with sessions."""
+    agents_root = get_agents_root()
+    if not agents_root.exists():
+        return []
+
+    agents = []
+    for agent_dir in agents_root.iterdir():
+        if not agent_dir.is_dir():
+            continue
+
+        sessions_json = agent_dir / "sessions" / "sessions.json"
+        if sessions_json.exists():
+            agents.append(agent_dir.name)
+
+    return agents
+
+
+def read_sessions_index(agent_id: str) -> dict | None:
+    """Read the sessions.json index for an agent."""
+    sessions_json = get_sessions_root(agent_id) / "sessions.json"
+    if not sessions_json.exists():
+        return None
+
+    try:
+        return json.loads(sessions_json.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def get_session_name(agent_id: str, session_id: str) -> str | None:
+    """Get the display name for a session from the sessions.json index.
+
+    OpenClaw's sessions.json uses session keys like "agent:main:testing-session"
+    as top-level keys, with optional "label" field for user-assigned names.
+    Each session object has a "sessionId" field with the UUID.
+
+    Priority: label > last segment of session key
+    """
+    index = read_sessions_index(agent_id)
+    if not index:
+        return None
+
+    # sessions.json has session keys as top-level keys (not a "sessions" array)
+    # e.g., {"agent:main:main": {"sessionId": "abc-123", "label": "My Session", ...}}
+    for session_key, session_data in index.items():
+        if not isinstance(session_data, dict):
+            continue
+
+        # Match by sessionId field (the UUID we have)
+        data_id = session_data.get("sessionId") or session_data.get("id")
+        if not data_id:
+            continue
+
+        # Check if our session_id matches (could be full UUID or prefix)
+        if (
+            data_id == session_id
+            or data_id.startswith(session_id)
+            or session_id.startswith(data_id[:8])
+        ):
+            # Priority: label > last segment of session key
+            label = session_data.get("label")
+            if label:
+                return label
+
+            # Extract last segment from session key (e.g., "testing-session" from "agent:main:testing-session")
+            if ":" in session_key:
+                return session_key.rsplit(":", 1)[-1]
+
+            return session_key
+
+    return None
+
+
+def get_last_user_message(session_path: Path, max_bytes: int = 64 * 1024) -> str | None:
+    """Get the last user message from a session file.
+
+    Reads the tail of the file and finds the most recent user message.
+    Returns the message text (truncated if long), or None if not found.
+    """
+    try:
+        file_size = session_path.stat().st_size
+        read_size = min(file_size, max_bytes)
+
+        with open(session_path, encoding="utf-8", errors="replace") as f:
+            if file_size > read_size:
+                f.seek(file_size - read_size)
+                f.readline()  # Skip partial line
+            content = f.read()
+
+        lines = content.strip().split("\n")
+
+        # Search from end for user message
+        for line in reversed(lines):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get("type")
+
+            if entry_type == "message":
+                msg = entry.get("message", {})
+                role = entry.get("role") or msg.get("role")
+                if role == "user":
+                    # Extract text content
+                    content = entry.get("content") or msg.get("content", [])
+                    text = _extract_text_from_content(content)
+                    if text:
+                        # Truncate if long
+                        if len(text) > 80:
+                            return text[:77] + "..."
+                        return text
+
+    except OSError:
+        pass
+
+    return None
+
+
+def _extract_text_from_content(content: list | str) -> str | None:
+    """Extract text from message content (handles string or content blocks)."""
+    if isinstance(content, str):
+        return content.strip() if content.strip() else None
+
+    if not isinstance(content, list):
+        return None
+
+    for block in content:
+        if isinstance(block, str):
+            if block.strip():
+                return block.strip()
+        elif isinstance(block, dict):
+            block_type = block.get("type")
+            if block_type in ("text", "input_text"):
+                text = block.get("text", "")
+                if text.strip():
+                    return text.strip()
+
+    return None
+
+
+def find_recent_session_for_cwd(cwd: str) -> tuple[Path | None, str | None, str | None]:
+    """Find the most recently modified session file for a given cwd.
+
+    Scans all agents' session files and returns the one most recently modified
+    that matches the given working directory.
+
+    Returns (session_path, session_id, agent_id) or (None, None, None).
+    """
+    agents_root = get_agents_root()
+    if not agents_root.exists():
+        return None, None, None
+
+    # Normalize cwd for comparison
+    cwd = str(Path(cwd).resolve())
+
+    best_match: tuple[Path, str, str, float] | None = None
+
+    for agent_dir in agents_root.iterdir():
+        if not agent_dir.is_dir():
+            continue
+
+        sessions_dir = agent_dir / "sessions"
+        if not sessions_dir.exists():
+            continue
+
+        for session_path in sessions_dir.glob("*.jsonl"):
+            if not session_path.is_file():
+                continue
+
+            # Read header to check cwd
+            header = read_session_header(session_path)
+            if not header:
+                continue
+
+            session_cwd = header.get("cwd")
+            if not session_cwd:
+                continue
+
+            # Normalize and compare
+            if str(Path(session_cwd).resolve()) != cwd:
+                continue
+
+            # Get modification time
+            mtime = session_path.stat().st_mtime
+
+            # Extract session ID
+            session_id = header.get("id") or extract_session_id_from_filename(session_path.name)
+            if not session_id:
+                continue
+
+            if best_match is None or mtime > best_match[3]:
+                best_match = (session_path, session_id, agent_dir.name, mtime)
+
+    if best_match:
+        return best_match[0], best_match[1], best_match[2]
+
+    return None, None, None
+
+
+def find_most_recent_session() -> tuple[Path | None, str | None, str | None, str | None]:
+    """Find the most recently modified session file across all agents.
+
+    Returns (session_path, session_id, agent_id, cwd) or (None, None, None, None).
+    """
+    agents_root = get_agents_root()
+    if not agents_root.exists():
+        return None, None, None, None
+
+    best_match: tuple[Path, str, str, str, float] | None = None
+
+    for agent_dir in agents_root.iterdir():
+        if not agent_dir.is_dir():
+            continue
+
+        sessions_dir = agent_dir / "sessions"
+        if not sessions_dir.exists():
+            continue
+
+        for session_path in sessions_dir.glob("*.jsonl"):
+            if not session_path.is_file():
+                continue
+
+            # Get modification time
+            mtime = session_path.stat().st_mtime
+
+            # Read header
+            header = read_session_header(session_path)
+            if not header:
+                continue
+
+            # Extract session ID
+            session_id = header.get("id") or extract_session_id_from_filename(session_path.name)
+            if not session_id:
+                continue
+
+            session_cwd = header.get("cwd", "")
+
+            if best_match is None or mtime > best_match[4]:
+                best_match = (session_path, session_id, agent_dir.name, session_cwd, mtime)
+
+    if best_match:
+        return best_match[0], best_match[1], best_match[2], best_match[3]
+
+    return None, None, None, None

--- a/src/lemonaid/openclaw/watcher.py
+++ b/src/lemonaid/openclaw/watcher.py
@@ -1,0 +1,204 @@
+"""OpenClaw session watcher backend.
+
+Provides OpenClaw-specific functions for the unified watcher:
+- get_session_path: Find session files
+- describe_activity: Describe what OpenClaw is doing
+- should_dismiss: Detect when to auto-dismiss notifications
+
+OpenClaw session entries have these types:
+- message: user/assistant messages with role and content
+- custom_message: extension-injected messages that enter model context
+- custom: extension state excluded from model context
+- compaction: persisted summaries
+- branch_summary: persisted summary when navigating trees
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .utils import find_session_path as _find_session_path
+
+CHANNEL_PREFIX = "openclaw:"
+
+
+def get_session_path(session_id: str, cwd: str) -> Path | None:
+    """Find an OpenClaw session file by session ID.
+
+    OpenClaw stores sessions in ~/.openclaw/agents/<agentId>/sessions/
+    with filenames like: <sessionId>.jsonl
+
+    Note: The cwd parameter is provided for API compatibility but OpenClaw
+    organizes by agent, not cwd. We search all agents.
+    """
+    return _find_session_path(session_id)
+
+
+def describe_activity(entry: dict) -> str | None:
+    """Extract a human-readable description of what OpenClaw is doing.
+
+    OpenClaw session entries have different formats:
+    - message: User/assistant messages with content array
+    - tool_use within content: Tool invocations
+    - text within content: Plain text responses
+    """
+    entry_type = entry.get("type")
+
+    if entry_type == "message":
+        return _describe_message(entry)
+
+    if entry_type == "compaction":
+        return "Compacting context..."
+
+    # custom_message - extension-injected content
+    if entry_type == "custom_message":
+        content = entry.get("content", [])
+        return _describe_content(content)
+
+    return None
+
+
+def should_dismiss(entry: dict) -> bool:
+    """Check if a session entry indicates we should dismiss the notification.
+
+    Dismiss (mark as read) when the user provides input.
+    """
+    entry_type = entry.get("type")
+
+    if entry_type == "message":
+        msg = entry.get("message", {})
+        role = entry.get("role") or msg.get("role")
+
+        # User input = dismiss
+        if role == "user":
+            return True
+
+    return False
+
+
+def needs_attention(entry: dict) -> bool:
+    """Check if a session entry indicates the agent is waiting for user input.
+
+    OpenClaw signals turn completion with stopReason: "stop" on assistant messages.
+    This means the agent has finished and is waiting for the user.
+    """
+    entry_type = entry.get("type")
+
+    if entry_type == "message":
+        msg = entry.get("message", {})
+        role = entry.get("role") or msg.get("role")
+        stop_reason = entry.get("stopReason") or msg.get("stopReason")
+
+        # Assistant message with stopReason="stop" means turn complete
+        if role == "assistant" and stop_reason == "stop":
+            return True
+
+    return False
+
+
+def _describe_message(entry: dict) -> str | None:
+    """Describe a message entry."""
+    msg = entry.get("message", {})
+    role = entry.get("role") or msg.get("role")
+    content = entry.get("content") or msg.get("content", [])
+
+    if role == "assistant":
+        return _describe_content(content)
+
+    return None
+
+
+def _describe_content(content: list | str) -> str | None:
+    """Describe content from a message entry."""
+    if isinstance(content, str):
+        if content.strip():
+            first_line = content.strip().split("\n")[0][:60]
+            if len(first_line) < len(content.strip().split("\n")[0]):
+                first_line += "..."
+            return first_line
+        return None
+
+    if not isinstance(content, list):
+        return None
+
+    # Look for tool_use or text blocks
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+
+        block_type = block.get("type")
+
+        if block_type in ("tool_use", "toolCall"):
+            return _describe_tool_use(block)
+
+        if block_type in ("text", "output_text"):
+            text = block.get("text", "")
+            if text.strip():
+                first_line = text.strip().split("\n")[0][:60]
+                if len(first_line) < len(text.strip().split("\n")[0]):
+                    first_line += "..."
+                return first_line
+
+    return None
+
+
+def _describe_tool_use(block: dict) -> str:
+    """Describe a tool_use block."""
+    name = block.get("name") or block.get("toolName", "unknown")
+    input_data = block.get("input") or block.get("arguments", {})
+
+    # Common tool patterns (based on Claude Code tools, which OpenClaw may use)
+    if name in ("Read", "read_file"):
+        path = input_data.get("file_path", input_data.get("path", ""))
+        if path:
+            filename = Path(path).name
+            return f"Reading {filename}"
+        return "Reading file"
+
+    if name in ("Edit", "edit_file"):
+        path = input_data.get("file_path", input_data.get("path", ""))
+        if path:
+            filename = Path(path).name
+            return f"Editing {filename}"
+        return "Editing file"
+
+    if name in ("Write", "write_file"):
+        path = input_data.get("file_path", input_data.get("path", ""))
+        if path:
+            filename = Path(path).name
+            return f"Writing {filename}"
+        return "Writing file"
+
+    if name in ("Bash", "shell", "shell_command"):
+        cmd = input_data.get("command", "")
+        if cmd:
+            if len(cmd) > 40:
+                return f"Running: {cmd[:37]}..."
+            return f"Running: {cmd}"
+        return "Running command"
+
+    if name in ("Grep", "search", "grep"):
+        pattern = input_data.get("pattern", input_data.get("query", ""))
+        if pattern:
+            return f"Searching: {pattern[:30]}"
+        return "Searching"
+
+    if name in ("Glob", "find_files"):
+        pattern = input_data.get("pattern", "")
+        if pattern:
+            return f"Finding: {pattern[:30]}"
+        return "Finding files"
+
+    if name in ("WebFetch", "web_fetch", "fetch"):
+        url = input_data.get("url", "")
+        if url:
+            return f"Fetching: {url[:30]}"
+        return "Fetching URL"
+
+    if name in ("WebSearch", "web_search"):
+        query = input_data.get("query", "")
+        if query:
+            return f"Searching: {query[:30]}"
+        return "Web search"
+
+    return f"Using {name}"


### PR DESCRIPTION
## Summary

Add support for [OpenClaw](https://openclaw.ai/), the open-source personal AI assistant. Follows the same architecture as Claude and Codex integrations.

Key features:
- **Turn-complete detection** - Detects `stopReason: "stop"` in transcripts to mark notifications as needing attention when the agent finishes
- **Auto-dismiss** - Marks notifications as read when user provides input
- **Live activity updates** - Shows what OpenClaw is doing in real-time
- **Session registration** - `!lreg` command captures TTY for tmux pane switching

## Usage

From within OpenClaw TUI, register the session:
```
!lemonaid openclaw register
```

Or with the shell alias (see docs):
```
!lreg
```

This captures the TTY and shows confirmation:
```
Registered most recent session (tty: ttys005)
  Channel: openclaw:a1b2c3d4
  Cwd: /Users/peter/clawd
  Name: main
  Last input: help me refactor the database module
```

## Changes

New files:
- `src/lemonaid/openclaw/` - OpenClaw package (cli, watcher, notify, utils)
- `docs/openclaw.md` - Setup and usage documentation

Modified:
- `cli.py` - Register openclaw subcommand
- `inbox/tui/app.py` - Add openclaw watcher backend, mark_unread callback
- `inbox/db.py` - Add `mark_unread_for_channel()` with flip-flop prevention
- `lemon_watchers/watcher.py` - Add `needs_attention` support for turn-complete detection
- `lemon_watchers/common.py` - Walk process tree for ancestor TTY detection
- `handlers.py` - CWD-based fallback for tmux pane lookup
- `tmux/__init__.py` - Add `get_pane_for_cwd()`
- `claude/watcher.py`, `codex/watcher.py` - Add `needs_attention()` stubs

## Technical notes

- OpenClaw hooks run in the Gateway process (Node.js), not the TUI, so can't capture TTY directly
- The `register` command runs via `!` prefix in TUI, which spawns from the TUI process, allowing TTY capture
- Session matching uses most-recently-modified heuristic with confirmation output (name + last user input)
- Session names come from OpenClaw's sessions.json (`label` field or session key segment)

## Test plan

- [x] Tested on machine with OpenClaw - sessions appear in `lma`
- [x] Turn-complete detection marks notifications as needing attention
- [x] Auto-dismiss works when user provides input  
- [x] `!lreg` registers session with correct TTY
- [x] Selecting notification switches to correct tmux pane
- [x] Session names display correctly