### PR TITLE
docs: fix example tmux config to match window_status.py arg signature

### DIFF
--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -170,8 +170,8 @@ set-option -sa terminal-features ',xterm-256color:RGB'
 
 # Window status with colored directory names
 # Third argument is pane_title - used to show app names instead of "python3.12"
-setw -g window-status-format " " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}') "
-setw -g window-status-current-format " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}' '1') "
+setw -g window-status-format " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}' '#{window_active}') "
+setw -g window-status-current-format " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}' '#{window_active}') "
 setw -g window-status-style none
 setw -g window-status-current-style "bg=colour238,bold"
 setw -g window-status-separator "│"

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -170,8 +170,8 @@ set-option -sa terminal-features ',xterm-256color:RGB'
 
 # Window status with colored directory names
 # Third argument is pane_title - used to show app names instead of "python3.12"
-setw -g window-status-format " #I:#(lemonaid-tmux-window-status '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}') "
-setw -g window-status-current-format " #I:#(lemonaid-tmux-window-status '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}') "
+setw -g window-status-format " " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}') "
+setw -g window-status-current-format " #I:#(lemonaid-tmux-window-status '#{pane_path}' '#{pane_current_path}' '#{pane_current_command}' '#{pane_title}' '1') "
 setw -g window-status-style none
 setw -g window-status-current-style "bg=colour238,bold"
 setw -g window-status-separator "│"


### PR DESCRIPTION
## Summary
- The example tmux config in `docs/tmux.md` was missing the `#{pane_path}` (OSC 7) argument that `window_status.py` expects as its first positional arg
- Without it, all subsequent arguments were shifted by one position — `pane_current_path` was read as `pane_path`, `pane_current_command` as `pane_current_path`, and `pane_title` as the process name
- Also adds the active flag (`'1'`) to `window-status-current-format` so the active window can use distinct process colors

## Test plan
- [ ] Verify the example config in `docs/tmux.md` matches the arg signature in `window_status.py:main()`
- [ ] Apply the updated config in a tmux session and confirm window status displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)