### PR TITLE
fix: separate non-switchable sessions into navigable lower pane

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+# 0.6.1 (2026-02-11)
+
+#### Fixed
+
+- **Non-switchable sessions in lower pane**: Sessions without a matching `switch_source` (NULL or different env) now always appear in a separate non-switchable section instead of mixing into the main table. Replaces the `show_all_sources` config option.
+- **Stale session cleanup across all sources**: Watcher now checks all sessions for dead panes/processes, not just those matching the current environment.
+- **Navigable non-switchable pane**: Arrow keys flow between main and non-switchable tables; archive/mark-read work on both, but Enter/select is blocked on non-switchable sessions.
+- **Smart timestamps**: Sessions older than 24 hours show date instead of time.
+
+#### Removed
+
+- `show_all_sources` TUI config option (non-switchable sessions are now always shown)
+
 # 0.6.0 (2026-02-03)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.6.0"
+version = "0.6.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -73,7 +73,6 @@ class TuiConfig:
     """Configuration for the TUI."""
 
     transparent: bool = False  # Use ANSI colors for terminal transparency
-    show_all_sources: bool = False  # Show sessions from all sources (tmux+wezterm)
     keybindings: KeybindingsConfig = field(default_factory=KeybindingsConfig)
 
 
@@ -139,7 +138,6 @@ def _parse_config(data: dict[str, Any]) -> Config:
     )
     tui = TuiConfig(
         transparent=tui_data.get("transparent", False),
-        show_all_sources=tui_data.get("show_all_sources", False),
         keybindings=keybindings,
     )
 

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -142,8 +142,7 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
     """Get active sessions (one per channel), unread first then by recency.
 
     Returns only the most recent notification per channel, excluding archived.
-    If switch_source is provided, filters to only notifications from that source
-    (or with NULL switch_source for backwards compatibility).
+    If switch_source is provided, filters to only notifications with that exact source.
     """
     if switch_source:
         rows = conn.execute(
@@ -155,7 +154,7 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
             WHERE n.status != 'archived'
-            AND (n.switch_source = ? OR n.switch_source IS NULL)
+            AND n.switch_source = ?
             ORDER BY
                 CASE n.status WHEN 'unread' THEN 0 ELSE 1 END,
                 n.created_at DESC


### PR DESCRIPTION
## Summary

- Sessions with NULL or mismatched `switch_source` now always appear in a separate "non-switchable" section below the main table, instead of mixing in
- Arrow keys flow between the two tables; archive/mark-read work on both, but Enter/select is blocked on non-switchable rows
- Stale session cleanup now runs across all sessions so dead panes get auto-archived regardless of `switch_source`
- Timestamps show date (`2026-02-10`) instead of time for sessions older than 24h
- Removed dead `show_all_sources` config option

## Test plan

- [x] Verify non-switchable sessions appear in lower dim pane
- [x] Arrow down past bottom of main table enters non-switchable pane
- [x] Arrow up from top of non-switchable pane returns to main table
- [x] Enter/select does nothing on non-switchable rows
- [x] Archive (`a`) works on non-switchable rows
- [x] Stale sessions from other envs get auto-archived after watcher cycle
- [x] Old timestamps show date, recent ones show time
