### PR TITLE
fix: preserve user-set session names across upserts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.6.2 (2026-02-11)
+
+#### Fixed
+
+- **Rename persistence**: User-set session names via the TUI rename action now survive notification upserts. Previously, every hook firing (idle, turn-complete, etc.) would overwrite the custom name with the auto-detected one.
+
 # 0.6.1 (2026-02-11)
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.6.1"
+version = "0.6.2"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -218,6 +218,12 @@ def add(
         # Look for any existing notification for this channel (including read/archived)
         existing = get_by_channel(conn, channel, unread_only=False)
         if existing:
+            # Preserve user-set name: if auto_name is in existing metadata,
+            # the user renamed this session — keep their name and carry forward auto_name.
+            if "auto_name" in existing.metadata:
+                metadata["auto_name"] = existing.metadata["auto_name"]
+                name = existing.name
+
             conn.execute(
                 """
                 UPDATE notifications


### PR DESCRIPTION
## Summary

- `db.add(upsert=True)` now checks for `auto_name` in existing notification metadata before overwriting the `name` field
- If the user renamed a session via the TUI, the custom name is preserved when hooks fire (idle, turn-complete, etc.)

## Test plan

- [x] Rename a session in the TUI, wait for a hook to fire, verify name persists
- [x] Clear a renamed session (set name to empty), verify auto-detected name restores