### PR TITLE
feat: session history, resume, and TUI improvements (v0.7.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+# 0.7.0 (2026-02-11)
+
+#### Added
+
+- **Session history**: Press `h` to browse archived sessions. Filter with `/`, resume with Enter. In non-scratch mode, Enter replaces the current terminal with the resumed session (`claude --resume`). In scratch mode or with `c`, the command is copied to clipboard.
+- **Git branch in metadata**: Notification hooks now record the git branch, displayed in the history view.
+- **CWD and branch columns**: Both main and history views now show CWD (fish-shell style abbreviation) and git branch.
+- **Purge command**: `lemonaid inbox purge [--older-than DAYS]` for manual cleanup of old sessions (default 90 days).
+
+#### Improved
+
+- **DataTable full-width**: Tables now stretch to fill the terminal width with proportional flex columns.
+- **Unified column layout**: Main and history views share the same columns — no visual jumping on toggle.
+- **Logging**: Switched to Python `logging` module; all components write to `/tmp/lemonaid.log` with hierarchical logger names.
+
 # 0.6.2 (2026-02-11)
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.6.2"
+version = "0.7.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/watcher.py
+++ b/src/lemonaid/claude/watcher.py
@@ -59,7 +59,7 @@ def describe_activity(entry: dict) -> str | None:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "")
                 if text.strip():
-                    first_line = text.strip().split("\n")[0][:60]
+                    first_line = text.strip().split("\n")[0][:200]
                     if len(first_line) < len(text.strip().split("\n")[0]):
                         first_line += "..."
                     return first_line
@@ -121,13 +121,13 @@ def _describe_tool_use(block: dict) -> str:
     if tool_name in ("Grep", "Glob"):
         pattern = tool_input.get("pattern", "")
         if pattern:
-            return f"Searching for {pattern[:30]}"
+            return f"Searching for {pattern[:80]}"
         return "Searching"
 
     if tool_name == "Task":
         desc = tool_input.get("description", "")
         if desc:
-            return f"Task: {desc[:40]}"
+            return f"Task: {desc[:80]}"
         return "Running task"
 
     if tool_name == "WebFetch":
@@ -136,7 +136,7 @@ def _describe_tool_use(block: dict) -> str:
     if tool_name == "WebSearch":
         query = tool_input.get("query", "")
         if query:
-            return f"Searching: {query[:30]}"
+            return f"Searching: {query[:80]}"
         return "Web search"
 
     return f"Using {tool_name}"

--- a/src/lemonaid/cli.py
+++ b/src/lemonaid/cli.py
@@ -127,6 +127,7 @@ def main() -> None:
 def inbox_main() -> None:
     """Direct entry point for `lma` alias - goes straight to inbox TUI."""
     import argparse
+    import os
 
     from .inbox.tui import LemonaidApp, set_terminal_title
 
@@ -141,6 +142,12 @@ def inbox_main() -> None:
     set_terminal_title("lma")
     app = LemonaidApp(scratch_mode=args.scratch)
     app.run()
+
+    # If the user chose to resume a session, exec it in this terminal
+    if app._exec_on_exit:
+        cwd, argv = app._exec_on_exit
+        os.chdir(cwd)
+        os.execvp(argv[0], argv)
 
 
 if __name__ == "__main__":

--- a/src/lemonaid/codex/notify.py
+++ b/src/lemonaid/codex/notify.py
@@ -10,16 +10,20 @@ from pathlib import Path
 from ..inbox import db
 from ..lemon_watchers import (
     detect_terminal_switch_source,
+    get_git_branch,
     get_name_from_cwd,
     get_tty,
     shorten_path,
 )
+from ..log import get_logger
 from .utils import (
     extract_session_id_from_filename,
     find_latest_session_for_cwd,
     find_session_path,
     read_session_meta,
 )
+
+_log = get_logger("codex.notify")
 
 
 def _parse_input_messages(data: dict) -> str | None:
@@ -97,18 +101,13 @@ def handle_notification(
     Reads JSON from stdin (as provided by Codex notify) and adds
     a notification to the lemonaid inbox.
     """
-    import time
-
-    log_file = "/tmp/lemonaid-codex-notify.log"
-
     if stdin_data is None:
         stdin_data = sys.stdin.read()
         # Codex notify passes a single JSON argument, not stdin.
         if not stdin_data.strip() and len(sys.argv) > 1 and sys.argv[-1].lstrip().startswith("{"):
             stdin_data = sys.argv[-1]
 
-    with open(log_file, "a") as f:
-        f.write(f"[{time.strftime('%H:%M:%S')}] stdin: {stdin_data[:200]}\n")
+    _log.info("stdin: %s", stdin_data[:200])
 
     try:
         data = json.loads(stdin_data) if stdin_data else {}
@@ -160,6 +159,9 @@ def handle_notification(
     thread_id = data.get("thread_id") or data.get("thread-id") or data.get("threadId")
     if isinstance(thread_id, str) and thread_id:
         metadata["thread_id"] = thread_id
+    branch = get_git_branch(cwd or "")
+    if branch:
+        metadata["git_branch"] = branch
 
     # Try to get TTY for pane matching
     tty = get_tty()
@@ -180,10 +182,7 @@ def handle_notification(
             switch_source=switch_source if switch_source != "unknown" else None,
         )
 
-    with open(log_file, "a") as f:
-        f.write(
-            f"[{time.strftime('%H:%M:%S')}] added: channel={channel}, type={notification_type}\n"
-        )
+    _log.info("added: channel=%s, type=%s", channel, notification_type)
 
 
 def dismiss_session(session_id: str, debug: bool = False) -> int:
@@ -205,15 +204,11 @@ def dismiss_session(session_id: str, debug: bool = False) -> int:
 
 def handle_dismiss(debug: bool = False) -> None:
     """Dismiss (mark as read) the notification for this Codex session."""
-    import time
-
     debug = debug or os.environ.get("LEMONAID_DEBUG") == "1"
-    log_file = "/tmp/lemonaid-codex-dismiss.log"
 
     stdin_raw = sys.stdin.read() or "{}"
 
-    with open(log_file, "a") as f:
-        f.write(f"[{time.strftime('%H:%M:%S')}] stdin: {stdin_raw[:100]}\n")
+    _log.info("dismiss stdin: %s", stdin_raw[:100])
 
     try:
         data = json.loads(stdin_raw)
@@ -223,7 +218,4 @@ def handle_dismiss(debug: bool = False) -> None:
     session_id = _extract_session_id(data, None)
     count = dismiss_session(session_id or "", debug=debug)
 
-    with open(log_file, "a") as f:
-        f.write(
-            f"[{time.strftime('%H:%M:%S')}] session_id={session_id[:8] if session_id else 'NONE'}, marked={count}\n"
-        )
+    _log.info("dismiss: session_id=%s, marked=%d", session_id[:8] if session_id else "NONE", count)

--- a/src/lemonaid/codex/watcher.py
+++ b/src/lemonaid/codex/watcher.py
@@ -73,7 +73,7 @@ def describe_activity(entry: dict) -> str | None:
                 if isinstance(block, dict) and block.get("type") in ("output_text", "text"):
                     text = block.get("text", "")
                     if text.strip():
-                        first_line = text.strip().split("\n")[0][:60]
+                        first_line = text.strip().split("\n")[0][:200]
                         if len(first_line) < len(text.strip().split("\n")[0]):
                             first_line += "..."
                         return first_line
@@ -91,7 +91,7 @@ def describe_activity(entry: dict) -> str | None:
             if isinstance(action, dict):
                 query = action.get("query")
                 if isinstance(query, str) and query:
-                    return f"Searching: {query[:30]}"
+                    return f"Searching: {query[:80]}"
             return "Web search"
 
         if payload_type == "message":
@@ -103,7 +103,7 @@ def describe_activity(entry: dict) -> str | None:
                         if isinstance(block, dict) and block.get("type") == "output_text":
                             text = block.get("text", "")
                             if text.strip():
-                                first_line = text.strip().split("\n")[0][:60]
+                                first_line = text.strip().split("\n")[0][:200]
                                 if len(first_line) < len(text.strip().split("\n")[0]):
                                     first_line += "..."
                                 return first_line
@@ -169,8 +169,8 @@ def _describe_command(cmd: str) -> str:
         return "Running command"
 
     cmd = cmd.strip()
-    if len(cmd) > 50:
-        return f"Running: {cmd[:47]}..."
+    if len(cmd) > 120:
+        return f"Running: {cmd[:117]}..."
     return f"Running: {cmd}"
 
 
@@ -198,7 +198,7 @@ def _describe_function_call(payload: dict) -> str:
         if isinstance(args, dict):
             uri = args.get("uri", "") or ""
         if uri:
-            return f"Reading {uri[:30]}"
+            return f"Reading {uri[:80]}"
         return "Reading resource"
 
     return f"Using {name}"

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -65,6 +65,8 @@ class KeybindingsConfig:
     mark_read: str = "m"
     archive: str = "a"
     rename: str = "r"
+    history: str = "h"  # Toggle history view
+    copy_resume: str = "c"  # Copy resume command to clipboard
     up_down: str = ""  # 2-char string: up, down (e.g., "kj" for vim)
 
 

--- a/src/lemonaid/inbox/cli.py
+++ b/src/lemonaid/inbox/cli.py
@@ -87,6 +87,16 @@ def cmd_read(args: argparse.Namespace) -> None:
     print(f"Marked notification {args.id} as read")
 
 
+def cmd_purge(args: argparse.Namespace) -> None:
+    """Delete old archived/read notifications."""
+    with db.connect() as conn:
+        count = db.clear_old(conn, days=args.older_than)
+    if count > 0:
+        print(f"Purged {count} notification(s) older than {args.older_than} days")
+    else:
+        print("Nothing to purge")
+
+
 def cmd_tui(args: argparse.Namespace) -> None:
     """Launch the inbox TUI."""
     from .tui import LemonaidApp
@@ -128,6 +138,15 @@ def setup_parser(subparsers: argparse._SubParsersAction) -> None:
     read_parser = inbox_subparsers.add_parser("read", help="Mark notification as read")
     read_parser.add_argument("id", type=int, help="Notification ID")
     read_parser.set_defaults(func=cmd_read)
+
+    # inbox purge
+    purge_parser = inbox_subparsers.add_parser(
+        "purge", help="Delete old archived/read notifications"
+    )
+    purge_parser.add_argument(
+        "--older-than", type=int, default=90, help="Days threshold (default: 90)"
+    )
+    purge_parser.set_defaults(func=cmd_purge)
 
     # Default for bare "lemonaid inbox" is TUI
     inbox_parser.set_defaults(func=cmd_tui, inbox_command=None)

--- a/src/lemonaid/lemon_watchers/__init__.py
+++ b/src/lemonaid/lemon_watchers/__init__.py
@@ -2,6 +2,8 @@
 
 from .common import (
     detect_terminal_switch_source,
+    fish_path,
+    get_git_branch,
     get_name_from_cwd,
     get_tmux_session_name,
     get_tty,
@@ -20,7 +22,9 @@ from .watcher import (
 __all__ = [
     "WatcherBackend",
     "detect_terminal_switch_source",
+    "fish_path",
     "get_latest_activity",
+    "get_git_branch",
     "get_name_from_cwd",
     "get_tmux_session_name",
     "get_tty",

--- a/src/lemonaid/log.py
+++ b/src/lemonaid/log.py
@@ -1,0 +1,24 @@
+"""Shared logging for lemonaid.
+
+All components log to /tmp/lemonaid.log via Python's logging module.
+Filter with grep: grep 'lemonaid.claude' /tmp/lemonaid.log
+"""
+
+import logging
+from pathlib import Path
+
+_LOG_PATH = Path("/tmp/lemonaid.log")
+
+_handler = logging.FileHandler(_LOG_PATH)
+_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s", datefmt="%H:%M:%S"))
+
+_root = logging.getLogger("lemonaid")
+_root.addHandler(_handler)
+_root.setLevel(logging.DEBUG)
+# don't propagate to root logger (avoids duplicate output if someone
+# configures the root logger elsewhere)
+_root.propagate = False
+
+
+def get_logger(name: str) -> logging.Logger:
+    return _root.getChild(name)

--- a/src/lemonaid/openclaw/watcher.py
+++ b/src/lemonaid/openclaw/watcher.py
@@ -112,7 +112,7 @@ def _describe_content(content: list | str) -> str | None:
     """Describe content from a message entry."""
     if isinstance(content, str):
         if content.strip():
-            first_line = content.strip().split("\n")[0][:60]
+            first_line = content.strip().split("\n")[0][:200]
             if len(first_line) < len(content.strip().split("\n")[0]):
                 first_line += "..."
             return first_line
@@ -134,7 +134,7 @@ def _describe_content(content: list | str) -> str | None:
         if block_type in ("text", "output_text"):
             text = block.get("text", "")
             if text.strip():
-                first_line = text.strip().split("\n")[0][:60]
+                first_line = text.strip().split("\n")[0][:200]
                 if len(first_line) < len(text.strip().split("\n")[0]):
                     first_line += "..."
                 return first_line
@@ -172,33 +172,33 @@ def _describe_tool_use(block: dict) -> str:
     if name in ("Bash", "shell", "shell_command"):
         cmd = input_data.get("command", "")
         if cmd:
-            if len(cmd) > 40:
-                return f"Running: {cmd[:37]}..."
+            if len(cmd) > 120:
+                return f"Running: {cmd[:117]}..."
             return f"Running: {cmd}"
         return "Running command"
 
     if name in ("Grep", "search", "grep"):
         pattern = input_data.get("pattern", input_data.get("query", ""))
         if pattern:
-            return f"Searching: {pattern[:30]}"
+            return f"Searching: {pattern[:80]}"
         return "Searching"
 
     if name in ("Glob", "find_files"):
         pattern = input_data.get("pattern", "")
         if pattern:
-            return f"Finding: {pattern[:30]}"
+            return f"Finding: {pattern[:80]}"
         return "Finding files"
 
     if name in ("WebFetch", "web_fetch", "fetch"):
         url = input_data.get("url", "")
         if url:
-            return f"Fetching: {url[:30]}"
+            return f"Fetching: {url[:80]}"
         return "Fetching URL"
 
     if name in ("WebSearch", "web_search"):
         query = input_data.get("query", "")
         if query:
-            return f"Searching: {query[:30]}"
+            return f"Searching: {query[:80]}"
         return "Web search"
 
     return f"Using {name}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,8 @@ def test_keybindings_defaults():
     assert kb.mark_read == "m"
     assert kb.archive == "a"
     assert kb.rename == "r"
+    assert kb.history == "h"
+    assert kb.copy_resume == "c"
     assert kb.up_down == ""
 
 

--- a/tests/test_lemon_watchers.py
+++ b/tests/test_lemon_watchers.py
@@ -6,6 +6,7 @@ import json
 from datetime import UTC, datetime
 
 from lemonaid.lemon_watchers import (
+    fish_path,
     get_latest_activity,
     has_activity_since,
     parse_timestamp,
@@ -48,3 +49,29 @@ def test_has_activity_since(tmp_path):
 
     since = datetime(2026, 1, 24, 12, 2, 0, tzinfo=UTC).timestamp()
     assert not has_activity_since(session, since, lambda e: e.get("type") == "dismiss")
+
+
+def test_fish_path_under_home(monkeypatch):
+    monkeypatch.setattr(
+        "lemonaid.lemon_watchers.common.Path.home",
+        staticmethod(lambda: __import__("pathlib").Path("/Users/peter")),
+    )
+    assert fish_path("/Users/peter/play/lemonaid") == "~/p/lemonaid"
+    assert fish_path("/Users/peter/work/ds-monorepo/libs/gent") == "~/w/d/l/gent"
+
+
+def test_fish_path_shallow(monkeypatch):
+    monkeypatch.setattr(
+        "lemonaid.lemon_watchers.common.Path.home",
+        staticmethod(lambda: __import__("pathlib").Path("/Users/peter")),
+    )
+    assert fish_path("/Users/peter/play") == "~/play"
+    assert fish_path("/Users/peter") == "~"
+
+
+def test_fish_path_absolute():
+    assert fish_path("/etc/nginx/conf.d") == "/e/n/conf.d"
+
+
+def test_fish_path_empty():
+    assert fish_path("") == ""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -34,9 +34,7 @@ def test_describe_activity_tool_use_bash():
     entry = {
         "type": "assistant",
         "message": {
-            "content": [
-                {"type": "tool_use", "name": "Bash", "input": {"command": "pytest tests/"}}
-            ]
+            "content": [{"type": "tool_use", "name": "Bash", "input": {"command": "pytest tests/"}}]
         },
     }
     assert describe_activity(entry) == "Running pytest"
@@ -47,9 +45,7 @@ def test_describe_activity_tool_use_grep():
     entry = {
         "type": "assistant",
         "message": {
-            "content": [
-                {"type": "tool_use", "name": "Grep", "input": {"pattern": "def main"}}
-            ]
+            "content": [{"type": "tool_use", "name": "Grep", "input": {"pattern": "def main"}}]
         },
     }
     assert describe_activity(entry) == "Searching for def main"
@@ -77,26 +73,20 @@ def test_describe_activity_text_response():
     entry = {
         "type": "assistant",
         "message": {
-            "content": [
-                {"type": "text", "text": "Here's the solution:\n\nFirst, we need to..."}
-            ]
+            "content": [{"type": "text", "text": "Here's the solution:\n\nFirst, we need to..."}]
         },
     }
     assert describe_activity(entry) == "Here's the solution:"
 
 
 def test_describe_activity_text_truncation():
-    """describe_activity should truncate long text."""
+    """describe_activity should truncate very long text."""
     entry = {
         "type": "assistant",
-        "message": {
-            "content": [
-                {"type": "text", "text": "A" * 100}  # Very long first line
-            ]
-        },
+        "message": {"content": [{"type": "text", "text": "A" * 300}]},
     }
     result = describe_activity(entry)
-    assert len(result) <= 63  # 60 chars + "..."
+    assert len(result) <= 203  # 200 chars + "..."
     assert result.endswith("...")
 
 
@@ -133,9 +123,7 @@ def test_describe_activity_thinking_only():
     """describe_activity should return None for thinking-only entries."""
     entry = {
         "type": "assistant",
-        "message": {
-            "content": [{"type": "thinking", "thinking": "Let me think about this..."}]
-        },
+        "message": {"content": [{"type": "thinking", "thinking": "Let me think about this..."}]},
     }
     # Thinking-only entries return None so we keep looking for better messages
     assert describe_activity(entry) is None


### PR DESCRIPTION
## Summary

- **Session history browser**: `h` toggles between active inbox and archived session history. `/` filters by name, CWD, branch. Enter resumes (exec in non-scratch, clipboard in scratch). `c` always copies the resume command.
- **CWD and git branch columns**: Both main and history views show fish-shell-abbreviated CWD and git branch. Branch captured at notification time.
- **Full-width DataTable**: Tables stretch to fill terminal width with proportional flex columns (`_stretch_columns` + `on_resize`).
- **Unified column layout**: Main and history views share identical columns — no visual jumping on toggle.
- **Python `logging` module**: Replaced hand-rolled `log(tag, msg)` with `logging.getLogger` hierarchy writing to `/tmp/lemonaid.log`.
- **Purge CLI**: `lemonaid inbox purge [--older-than DAYS]` for manual cleanup.
- **OpenClaw resume support**: Stores `session_key` in metadata, delegates to `openclaw/utils.py:build_resume_argv()`.

## Test plan

- [x] `uv run pytest` — 39 tests pass
- [x] Start `lma`, press `h` — history appears with archived sessions
- [x] `/` filter narrows results, Escape clears
- [x] Enter on `claude:*` row in non-scratch: TUI exits, `claude --resume` runs
- [x] `c` copies resume command to clipboard
- [x] `q` quits directly from history (no intermediate active view)
- [x] Trigger notification — confirm `git_branch` in metadata
- [ ] `lemonaid inbox purge --older-than 7` removes old sessions