### PR TITLE
feat: add OpenCode integration (v0.10.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 0.10.0 (2026-02-19)
+
+#### Added
+
+- **OpenCode integration**: Added first-class OpenCode support with `lemonaid opencode notify` / `dismiss`, OpenCode docs, tmux process labels, and TUI resume support (`opencode --session ...`).
+- **OpenCode watcher behavior**: Notifications now auto-transition based on activity: unread on turn completion (`step-finish` with `reason: "stop"`) and read when session activity resumes.
+- **OpenCode channeling**: OpenCode notifications now key by full session ID (`opencode:<full_session_id>`) to avoid collisions between sessions sharing the same ID prefix.
+
 # 0.9.0 (2026-02-16)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The TUI doesn't need to be running for notifications to arrive (hooks write dire
 
 ## Features
 
-- **Notification inbox**: Track which [Claude Code](docs/claude.md), [Codex CLI](docs/codex.md), and [OpenClaw](docs/openclaw.md) sessions need your attention, and what they're doing as they do it
+- **Notification inbox**: Track which [Claude Code](docs/claude.md), [Codex CLI](docs/codex.md), [OpenClaw](docs/openclaw.md), and [OpenCode](docs/opencode.md) sessions need your attention, and what they're doing as they do it
 - **Terminal integration**: Hit enter to jump directly to the waiting session's pane (supports [`tmux`](docs/tmux.md) and [WezTerm](docs/wezterm.md))
 - **Session history & resume**: Browse archived sessions across all projects, filter by name/cwd/branch, and resume directly or copy the command
 - **Bootstrap**: `lemonaid claude bootstrap` imports historical Claude sessions from before lemonaid was installed into the archive
@@ -87,6 +87,24 @@ Features: turn-complete detection, live activity updates, auto-dismiss on user i
 
 **Full documentation**: [docs/openclaw.md](docs/openclaw.md)
 
+### OpenCode
+
+Add this plugin at `~/.config/opencode/plugins/lemonaid.js` (or `.opencode/plugins/lemonaid.js` in a project):
+
+```javascript
+export const LemonaidPlugin = async ({ $ }) => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle" || event.type === "permission.asked") {
+      await $`lemonaid opencode notify ${JSON.stringify(event)}`
+    }
+  },
+})
+```
+
+Features: idle/permission notifications via plugin hooks, auto-dismiss via session DB watching, live activity updates.
+
+**Full documentation**: [docs/opencode.md](docs/opencode.md)
+
 ## Terminal Setup
 
 - **`tmux`**: See [docs/tmux.md](docs/tmux.md) for pane switching, back navigation, session templates, and window colors
@@ -140,3 +158,4 @@ Config file: `~/.config/lemonaid/config.toml` — see [docs/config.md](docs/conf
 - **claude**: Claude Code hook integration with transcript watching
 - **codex**: Codex CLI hook integration with session watching
 - **openclaw**: OpenClaw integration with turn-complete detection
+- **opencode**: OpenCode integration with plugin events and live activity watching

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,80 @@
+# OpenCode Integration
+
+Lemonaid supports [OpenCode](https://opencode.ai/) sessions via plugin events and session DB watching.
+
+## How It Works
+
+1. OpenCode plugin emits events to `lemonaid opencode notify` when a session goes idle or asks permission
+2. Lemonaid stores notification metadata (`cwd`, `session_id`, `tty`, `switch_source`) in the inbox DB
+3. The unified watcher reads OpenCode session activity from `~/.local/share/opencode/opencode.db`
+4. When OpenCode resumes work (user/assistant activity, tool calls), the notification auto-marks as read
+5. When OpenCode completes a turn (`step-finish` with `reason: "stop"`), the watcher marks the session unread again
+
+## Setup
+
+### 1) Ensure lemonaid has OpenCode commands
+
+```bash
+lemonaid opencode --help
+```
+
+If this fails, reinstall your local editable tool:
+
+```bash
+cd ~/play/lemonaid
+uv tool install --editable . --reinstall
+```
+
+### 2) Add OpenCode plugin
+
+Create `~/.config/opencode/plugins/lemonaid.js` (global) or `.opencode/plugins/lemonaid.js` (project):
+
+```javascript
+export const LemonaidPlugin = async ({ $ }) => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle" || event.type === "permission.asked") {
+      await $`lemonaid opencode notify ${JSON.stringify(event)}`
+    }
+  },
+})
+```
+
+Restart OpenCode after adding the plugin.
+
+### 3) Verify notifications are flowing
+
+```bash
+# synthetic event (smoke test)
+lemonaid opencode notify '{"type":"session.idle","properties":{"sessionID":"ses_test123"}}'
+
+# verify in inbox
+lemonaid inbox list --json
+```
+
+### 4) Troubleshooting
+
+- Ensure plugin path is exactly `~/.config/opencode/plugins/lemonaid.js`
+- Fully restart OpenCode after plugin changes
+- Check logs: `rg 'lemonaid\.opencode|opencode\.notify|watcher' /tmp/lemonaid.log`
+
+## CLI Commands
+
+```bash
+# Manually trigger a notification
+lemonaid opencode notify '{"type":"session.idle","properties":{"sessionID":"ses_abc123"}}'
+
+# Mark a session notification as read
+lemonaid opencode dismiss --session-id ses_abc123
+```
+
+## Session Storage
+
+- OpenCode DB: `~/.local/share/opencode/opencode.db`
+- Session table: `session`
+- Activity stream used by watcher: `message` + `part`
+
+## Technical Notes
+
+- Channel format: `opencode:<full_session_id>`
+- Resume command from history: `opencode --session <session_id>`
+- Notifications include terminal metadata when available for tmux/wezterm switching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.9.0"
+version = "0.10.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/bootstrap.py
+++ b/src/lemonaid/claude/bootstrap.py
@@ -5,8 +5,6 @@ are invisible to lemonaid's history view. This module scans Claude's
 sessions-index.json files and imports them as archived notifications.
 """
 
-from __future__ import annotations
-
 import json
 import typing as ty
 from pathlib import Path

--- a/src/lemonaid/claude/summarize.py
+++ b/src/lemonaid/claude/summarize.py
@@ -1,7 +1,5 @@
 """Summarize Claude sessions with poor names using claude -p --model haiku."""
 
-from __future__ import annotations
-
 import json
 import subprocess
 import typing as ty

--- a/src/lemonaid/cli.py
+++ b/src/lemonaid/cli.py
@@ -12,6 +12,7 @@ from .config import ensure_config_exists, get_config_path
 from .inbox import cli as inbox_cli
 from .inbox import db as inbox_db
 from .openclaw import cli as openclaw_cli
+from .opencode import cli as opencode_cli
 from .tmux import cli as tmux_cli
 from .wezterm import cli as wezterm_cli
 
@@ -97,6 +98,7 @@ def main() -> None:
     claude_cli.setup_parser(subparsers)
     codex_cli.setup_parser(subparsers)
     openclaw_cli.setup_parser(subparsers)
+    opencode_cli.setup_parser(subparsers)
     tmux_cli.setup_parser(subparsers)
     wezterm_cli.setup_parser(subparsers)
     setup_config_parser(subparsers)

--- a/src/lemonaid/codex/notify.py
+++ b/src/lemonaid/codex/notify.py
@@ -1,7 +1,5 @@
 """Codex CLI notification hook handler."""
 
-from __future__ import annotations
-
 import json
 import os
 import sys

--- a/src/lemonaid/codex/utils.py
+++ b/src/lemonaid/codex/utils.py
@@ -1,7 +1,5 @@
 """Codex session utilities."""
 
-from __future__ import annotations
-
 import json
 import re
 from pathlib import Path

--- a/src/lemonaid/codex/watcher.py
+++ b/src/lemonaid/codex/watcher.py
@@ -6,8 +6,6 @@ Provides Codex-specific functions for the unified watcher:
 - should_dismiss: Detect when to auto-dismiss notifications
 """
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -77,7 +77,7 @@ class TuiConfig:
     transparent: bool = False  # Use ANSI colors for terminal transparency
     keybindings: KeybindingsConfig = field(default_factory=KeybindingsConfig)
     # Override the label shown for each backend in the TUI.
-    # Keys are channel prefixes (claude, codex, openclaw); values are display strings.
+    # Keys are channel prefixes (claude, codex, openclaw, opencode); values are display strings.
     # Unset backends default to their channel prefix.
     backend_labels: dict[str, str] = field(default_factory=dict)
 

--- a/src/lemonaid/handlers.py
+++ b/src/lemonaid/handlers.py
@@ -124,6 +124,8 @@ def _handle_tmux(metadata: dict[str, Any] | None) -> bool:
                 process_name = "claude"
             elif channel.startswith("codex:"):
                 process_name = "codex"
+            elif channel.startswith("opencode:"):
+                process_name = "opencode"
             session, pane_id = tmux.get_pane_for_cwd(cwd, process_name)
 
     if session is None or pane_id is None:

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -1,7 +1,5 @@
 """SQLite database for lemonaid notifications."""
 
-from __future__ import annotations
-
 import json
 import sqlite3
 import time
@@ -9,7 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 
 @dataclass(frozen=True)
@@ -27,7 +25,7 @@ class Notification:
     switch_source: str | None = None
 
     @classmethod
-    def from_row(cls, row: sqlite3.Row) -> Notification:
+    def from_row(cls, row: sqlite3.Row) -> Self:
         """Create a Notification from a database row."""
         # Handle columns which may not exist in older DBs
         switch_source = None

--- a/src/lemonaid/lemon_watchers/common.py
+++ b/src/lemonaid/lemon_watchers/common.py
@@ -1,7 +1,5 @@
 """Shared utilities for LLM integrations."""
 
-from __future__ import annotations
-
 import os
 import subprocess
 import sys

--- a/src/lemonaid/lemon_watchers/watcher.py
+++ b/src/lemonaid/lemon_watchers/watcher.py
@@ -4,8 +4,6 @@ Provides shared watcher loop logic that can be used by multiple backends
 (Claude, Codex, etc.) to monitor session files for activity.
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 import threading
@@ -249,6 +247,8 @@ def _archive_stale_sessions(
             process_name = "claude"
         elif channel.startswith("openclaw:"):
             process_name = "openclaw"
+        elif channel.startswith("opencode:"):
+            process_name = "opencode"
         else:
             process_name = "codex"
         key = (tty, process_name)

--- a/src/lemonaid/openclaw/notify.py
+++ b/src/lemonaid/openclaw/notify.py
@@ -5,8 +5,6 @@ this module provides the handler infrastructure in case hooks are added
 or for manual triggering.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import sys

--- a/src/lemonaid/openclaw/ssh.py
+++ b/src/lemonaid/openclaw/ssh.py
@@ -5,8 +5,6 @@ sessions on a remote host. They are NOT called in the hot polling
 loop — the watcher uses _read_jsonl_tail_ssh in watcher.py instead.
 """
 
-from __future__ import annotations
-
 import json
 import re
 import shlex

--- a/src/lemonaid/openclaw/utils.py
+++ b/src/lemonaid/openclaw/utils.py
@@ -1,7 +1,5 @@
 """OpenClaw session utilities."""
 
-from __future__ import annotations
-
 import json
 import re
 from pathlib import Path

--- a/src/lemonaid/openclaw/watcher.py
+++ b/src/lemonaid/openclaw/watcher.py
@@ -14,8 +14,6 @@ OpenClaw session entries have these types:
 - branch_summary: persisted summary when navigating trees
 """
 
-from __future__ import annotations
-
 import functools
 import shlex
 import subprocess

--- a/src/lemonaid/opencode/__init__.py
+++ b/src/lemonaid/opencode/__init__.py
@@ -1,0 +1,5 @@
+"""Lemonaid OpenCode integration.
+
+OpenCode stores session state in SQLite at:
+~/.local/share/opencode/opencode.db
+"""

--- a/src/lemonaid/opencode/cli.py
+++ b/src/lemonaid/opencode/cli.py
@@ -1,0 +1,79 @@
+"""CLI commands for OpenCode integration."""
+
+import argparse
+
+from .notify import _dismiss_session, handle_dismiss, handle_notification
+
+
+def cmd_notify(args: argparse.Namespace) -> None:
+    """Handle OpenCode notification hook."""
+    handle_notification(
+        stdin_data=args.payload,
+        session_id=args.session_id,
+        cwd=args.cwd,
+        name=args.name,
+        message=args.message,
+        notification_type=args.notification_type,
+    )
+
+
+def cmd_dismiss(args: argparse.Namespace) -> None:
+    """Handle OpenCode dismiss hook (mark notification as read)."""
+    if args.session_id:
+        _dismiss_session(args.session_id)
+    else:
+        handle_dismiss()
+
+
+def setup_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Set up the opencode subcommand."""
+    opencode_parser = subparsers.add_parser(
+        "opencode",
+        help="OpenCode integration",
+    )
+    opencode_subparsers = opencode_parser.add_subparsers(dest="opencode_command")
+
+    notify_parser = opencode_subparsers.add_parser(
+        "notify",
+        help="Handle notification from OpenCode plugin hook",
+    )
+    notify_parser.add_argument(
+        "payload",
+        nargs="?",
+        help="JSON payload from OpenCode plugin event",
+    )
+    notify_parser.add_argument(
+        "--session-id",
+        "-s",
+        help="OpenCode session ID",
+    )
+    notify_parser.add_argument(
+        "--cwd",
+        help="Working directory for the session",
+    )
+    notify_parser.add_argument(
+        "--name",
+        help="Display name for the session",
+    )
+    notify_parser.add_argument(
+        "--message",
+        help="Notification message override",
+    )
+    notify_parser.add_argument(
+        "--notification-type",
+        help="Notification/event type (e.g., session.idle, permission.asked)",
+    )
+    notify_parser.set_defaults(func=cmd_notify)
+
+    dismiss_parser = opencode_subparsers.add_parser(
+        "dismiss",
+        help="Mark session's notification as read (reads JSON from stdin)",
+    )
+    dismiss_parser.add_argument(
+        "--session-id",
+        "-s",
+        help="Session ID to dismiss (if not provided, reads from stdin)",
+    )
+    dismiss_parser.set_defaults(func=cmd_dismiss)
+
+    opencode_parser.set_defaults(func=lambda a: opencode_parser.print_help())

--- a/src/lemonaid/opencode/notify.py
+++ b/src/lemonaid/opencode/notify.py
@@ -1,0 +1,205 @@
+"""OpenCode notification hook handler."""
+
+import json
+import os
+import sys
+
+from ..inbox import db
+from ..lemon_watchers import (
+    detect_terminal_switch_source,
+    get_git_branch,
+    get_name_from_cwd,
+    get_tty,
+    shorten_path,
+)
+from ..log import get_logger
+from .utils import get_cwd_and_name
+
+_log = get_logger("opencode.notify")
+
+
+def _channel_for_session(session_id: str | None) -> str:
+    if not session_id:
+        return "opencode:unknown"
+    return f"opencode:{session_id}"
+
+
+def _extract_session_id(data: dict[str, object]) -> str | None:
+    keys = (
+        "session_id",
+        "sessionId",
+        "sessionID",
+        "id",
+    )
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    props_obj = data.get("properties")
+    props: dict[str, object] = props_obj if isinstance(props_obj, dict) else {}
+    for key in keys:
+        value = props.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    session_raw = data.get("session")
+    session_obj: dict[str, object] = session_raw if isinstance(session_raw, dict) else {}
+    for key in keys:
+        value = session_obj.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    props_session_raw = props.get("session")
+    props_session: dict[str, object] = (
+        props_session_raw if isinstance(props_session_raw, dict) else {}
+    )
+    for key in keys:
+        value = props_session.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    return None
+
+
+def _default_message(notification_type: str, cwd: str | None) -> str:
+    short_path = shorten_path(cwd) if cwd else "OpenCode"
+    if "permission" in notification_type:
+        return f"Permission needed in {short_path}"
+    if notification_type == "session.idle":
+        return f"Waiting in {short_path}"
+    return f"{notification_type} in {short_path}"
+
+
+def handle_notification(
+    stdin_data: str | None = None,
+    *,
+    session_id: str | None = None,
+    cwd: str | None = None,
+    name: str | None = None,
+    message: str | None = None,
+    notification_type: str | None = None,
+) -> None:
+    """Handle an OpenCode notification from stdin or explicit args."""
+    if stdin_data is None:
+        stdin_data = sys.stdin.read() if not sys.stdin.isatty() else ""
+    stdin_data = stdin_data or ""
+
+    _log.info("stdin: %s", stdin_data[:200])
+
+    try:
+        loaded = json.loads(stdin_data) if stdin_data else {}
+    except json.JSONDecodeError:
+        loaded = {}
+
+    data: dict[str, object] = loaded if isinstance(loaded, dict) else {}
+
+    data_type = data.get("type")
+    data_event = data.get("event")
+    if not notification_type:
+        if isinstance(data_type, str) and data_type:
+            notification_type = data_type
+        elif isinstance(data_event, str) and data_event:
+            notification_type = data_event
+        else:
+            notification_type = "session.idle"
+    session_id = session_id or _extract_session_id(data)
+
+    if session_id and (not cwd or not name):
+        discovered_cwd, discovered_name = get_cwd_and_name(session_id)
+        cwd = cwd or discovered_cwd
+        name = name or discovered_name
+
+    if not cwd:
+        directory = data.get("directory")
+        cwd_value = data.get("cwd")
+        cwd = (
+            directory
+            if isinstance(directory, str)
+            else cwd_value
+            if isinstance(cwd_value, str)
+            else None
+        )
+    if not name:
+        title = data.get("title")
+        data_name = data.get("name")
+        name = (
+            title
+            if isinstance(title, str)
+            else data_name
+            if isinstance(data_name, str)
+            else get_name_from_cwd(cwd or "")
+        )
+
+    message = message or _default_message(notification_type, cwd)
+
+    switch_source = detect_terminal_switch_source()
+    metadata: dict[str, str] = {}
+    if cwd:
+        metadata["cwd"] = cwd
+    if session_id:
+        metadata["session_id"] = session_id
+    metadata["notification_type"] = notification_type
+
+    branch = get_git_branch(cwd or "")
+    if branch:
+        metadata["git_branch"] = branch
+
+    tty = get_tty()
+    if tty:
+        metadata["tty"] = tty
+
+    channel = _channel_for_session(session_id)
+
+    with db.connect() as conn:
+        db.add(
+            conn,
+            channel=channel,
+            message=message,
+            name=name,
+            metadata=metadata,
+            switch_source=switch_source if switch_source != "unknown" else None,
+        )
+
+    _log.info("added: channel=%s, type=%s", channel, notification_type)
+
+
+def _dismiss_session(session_id: str, debug: bool = False) -> int:
+    """Dismiss (mark as read) the notification for an OpenCode session."""
+    if not session_id:
+        if debug:
+            print("[dismiss] no session_id provided", file=sys.stderr)
+        return 0
+
+    channel = _channel_for_session(session_id)
+    with db.connect() as conn:
+        count = db.mark_all_read_for_channel(conn, channel)
+        # Backward compatibility for notifications created with legacy short channel ids
+        legacy_channel = f"opencode:{session_id[:8]}"
+        if legacy_channel != channel:
+            count += db.mark_all_read_for_channel(conn, legacy_channel)
+        if debug:
+            print(
+                f"[dismiss] marked {count} notification(s) as read for {channel}",
+                file=sys.stderr,
+            )
+        return count
+
+
+def handle_dismiss(debug: bool = False) -> None:
+    """Dismiss (mark as read) the notification for this OpenCode session."""
+    debug = debug or os.environ.get("LEMONAID_DEBUG") == "1"
+
+    stdin_raw = (sys.stdin.read() if not sys.stdin.isatty() else "{}") or "{}"
+
+    _log.info("dismiss stdin: %s", stdin_raw[:100])
+
+    try:
+        data = json.loads(stdin_raw)
+    except json.JSONDecodeError:
+        data = {}
+
+    session_id = _extract_session_id(data)
+    count = _dismiss_session(session_id or "", debug=debug)
+
+    _log.info("dismiss: session_id=%s, marked=%d", session_id[:8] if session_id else "NONE", count)

--- a/src/lemonaid/opencode/utils.py
+++ b/src/lemonaid/opencode/utils.py
@@ -1,0 +1,66 @@
+"""OpenCode session utilities."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+
+def get_db_path() -> Path:
+    """Return the OpenCode SQLite database path."""
+    return Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+
+
+def _get_session(session_id: str) -> dict | None:
+    """Get OpenCode session row by id, parsing JSON fields."""
+    if not session_id:
+        return None
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        return None
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            columns = {r[1] for r in conn.execute("PRAGMA table_info(session)").fetchall()}
+            has_data = "data" in columns
+            query = (
+                "SELECT id, title, directory, data FROM session WHERE id = ?"
+                if has_data
+                else "SELECT id, title, directory FROM session WHERE id = ?"
+            )
+            row = conn.execute(query, (session_id,)).fetchone()
+    except sqlite3.Error:
+        return None
+
+    if not row:
+        return None
+
+    data = {}
+    if len(row) > 3:
+        data_raw = row[3]
+        if isinstance(data_raw, str) and data_raw:
+            try:
+                data = json.loads(data_raw)
+            except json.JSONDecodeError:
+                data = {}
+
+    return {
+        "id": row[0],
+        "title": row[1],
+        "directory": row[2],
+        "data": data,
+    }
+
+
+def get_cwd_and_name(session_id: str) -> tuple[str | None, str | None]:
+    """Resolve cwd and display name for an OpenCode session id."""
+    session = _get_session(session_id)
+    if not session:
+        return None, None
+
+    directory = session.get("directory")
+    data = session.get("data", {})
+
+    cwd = directory or data.get("directory") or data.get("path", {}).get("cwd")
+    name = session.get("title")
+    return cwd, name

--- a/src/lemonaid/opencode/watcher.py
+++ b/src/lemonaid/opencode/watcher.py
@@ -1,0 +1,172 @@
+"""OpenCode session watcher backend."""
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .utils import get_db_path
+
+CHANNEL_PREFIX = "opencode:"
+
+
+def _to_iso(ts_ms: int) -> str:
+    return datetime.fromtimestamp(ts_ms / 1000, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def get_session_path(session_id: str, cwd: str) -> Path | None:
+    """Return a synthetic path encoding db-path and session id."""
+    if not session_id:
+        return None
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        return None
+
+    return Path(f"{db_path}#{session_id}")
+
+
+def read_lines(session_path: Path) -> list[str]:
+    """Read recent session parts from OpenCode SQLite DB as JSONL-style lines."""
+    raw_path = str(session_path)
+    if "#" not in raw_path:
+        return []
+
+    db_path_str, session_id = raw_path.rsplit("#", 1)
+    if not session_id:
+        return []
+
+    query = """
+        SELECT recent.part_data, recent.time_created, recent.message_data
+        FROM (
+            SELECT p.data AS part_data, p.time_created AS time_created, m.data AS message_data
+            FROM part p
+            JOIN message m ON m.id = p.message_id
+            WHERE p.session_id = ?
+            ORDER BY p.time_created DESC
+            LIMIT 120
+        ) AS recent
+        ORDER BY recent.time_created ASC
+    """
+
+    try:
+        with sqlite3.connect(db_path_str) as conn:
+            rows = conn.execute(query, (session_id,)).fetchall()
+    except sqlite3.Error:
+        return []
+
+    lines: list[str] = []
+    for part_data_raw, ts_ms, message_data_raw in rows:
+        try:
+            part_data = json.loads(part_data_raw)
+            message_data = json.loads(message_data_raw)
+        except (TypeError, json.JSONDecodeError):
+            continue
+
+        if not isinstance(ts_ms, int):
+            continue
+
+        lines.append(
+            json.dumps(
+                {
+                    "timestamp": _to_iso(ts_ms),
+                    "type": "part",
+                    "role": message_data.get("role"),
+                    "part": part_data,
+                }
+            )
+        )
+
+    return lines
+
+
+def _describe_tool(part: dict[str, object]) -> str:
+    tool_name_obj = part.get("tool", "unknown")
+    tool_name = tool_name_obj if isinstance(tool_name_obj, str) else "unknown"
+    state_obj = part.get("state")
+    state: dict[str, object] = state_obj if isinstance(state_obj, dict) else {}
+    input_obj = state.get("input")
+    tool_input: dict[str, object] = input_obj if isinstance(input_obj, dict) else {}
+
+    if tool_name == "read":
+        path = tool_input.get("filePath", "")
+        if isinstance(path, str) and path:
+            return f"Reading {Path(path).name}"
+        return "Reading file"
+
+    if tool_name in ("edit", "write"):
+        path = tool_input.get("filePath", "")
+        if isinstance(path, str) and path:
+            return f"Editing {Path(path).name}"
+        return "Editing file"
+
+    if tool_name == "bash":
+        cmd = tool_input.get("command", "")
+        if isinstance(cmd, str) and cmd:
+            return f"Running: {cmd[:120]}" if len(cmd) <= 120 else f"Running: {cmd[:117]}..."
+        return "Running command"
+
+    if tool_name in ("grep", "glob"):
+        pattern = tool_input.get("pattern", "")
+        if isinstance(pattern, str) and pattern:
+            return f"Searching: {pattern[:80]}"
+        return "Searching"
+
+    if tool_name == "webfetch":
+        return "Fetching web content"
+
+    return f"Using {tool_name}"
+
+
+def describe_activity(entry: dict) -> str | None:
+    """Extract a human-readable description of what OpenCode is doing."""
+    part = entry.get("part")
+    if not isinstance(part, dict):
+        return None
+
+    part_type = part.get("type")
+    if part_type == "tool":
+        return _describe_tool(part)
+
+    if part_type == "reasoning":
+        return "Thinking..."
+
+    if part_type == "text":
+        text = part.get("text", "")
+        if isinstance(text, str) and text.strip():
+            first_line = text.strip().split("\n")[0][:200]
+            if len(first_line) < len(text.strip().split("\n")[0]):
+                first_line += "..."
+            return first_line
+
+    if part_type == "step-start":
+        return "Working..."
+
+    return None
+
+
+def should_dismiss(entry: dict) -> bool:
+    """Check if a session entry indicates we should dismiss notification."""
+    role = entry.get("role")
+    part = entry.get("part")
+    if not isinstance(part, dict):
+        return False
+
+    if role in ("assistant", "user"):
+        return True
+
+    return part.get("type") in ("tool", "reasoning", "text", "step-start", "step-finish")
+
+
+def needs_attention(entry: dict) -> bool:
+    """Return True when OpenCode indicates assistant turn completion.
+
+    OpenCode emits assistant `step-finish` parts with `reason: "stop"`
+    when a turn is complete and waiting for user input.
+    """
+    part_obj = entry.get("part")
+    if not isinstance(part_obj, dict):
+        return False
+    part: dict[str, object] = part_obj
+
+    return part.get("type") == "step-finish" and part.get("reason") == "stop"

--- a/src/lemonaid/tmux/window_status.py
+++ b/src/lemonaid/tmux/window_status.py
@@ -77,10 +77,12 @@ PROCESS_COLORS: dict[str, str] = {
     "node": "#50FA7B",  # Green
     "npm": "#50FA7B",
     "claude": "#50FA7B",  # Green
+    "opencode": "#7DCFFF",  # Sky blue
 }
 
 ACTIVE_PROCESS_COLORS: dict[str, str] = {
     "codex": "#2FBF5A",  # Brighter for current window, still darker than Claude
+    "opencode": "#9AEDFE",  # Brighter sky blue
 }
 
 # Shells/wrappers that shouldn't be shown (just show directory instead)
@@ -99,6 +101,7 @@ HIDDEN_PROCESSES: set[str] = {
 STANDALONE_PROCESSES: set[str] = {
     "claude",
     "codex",
+    "opencode",
     "emacs",
     "emacsclient",
     "lma",

--- a/tests/test_lemon_watchers.py
+++ b/tests/test_lemon_watchers.py
@@ -1,7 +1,5 @@
 """Tests for lemon_watchers shared utilities."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 

--- a/tests/test_openclaw_ssh.py
+++ b/tests/test_openclaw_ssh.py
@@ -3,8 +3,6 @@
 All tests mock subprocess.run to avoid real SSH calls.
 """
 
-from __future__ import annotations
-
 import json
 import shlex
 import subprocess
@@ -124,7 +122,7 @@ def test_find_most_recent_session_success(mock_ssh):
 @patch("lemonaid.openclaw.ssh._ssh_run")
 def test_find_most_recent_session_no_files(mock_ssh):
     mock_ssh.return_value = None
-    path, session_id, agent_id, cwd = find_most_recent_session("host")
+    path, session_id, _agent_id, _cwd = find_most_recent_session("host")
     assert path is None
     assert session_id is None
 
@@ -135,7 +133,7 @@ def test_find_most_recent_session_no_uuid(mock_ssh):
     mock_ssh.side_effect = [
         "/home/.openclaw/agents/a1/sessions/no-uuid-here.jsonl",  # ls
     ]
-    path, session_id, agent_id, cwd = find_most_recent_session("host")
+    path, _session_id, _agent_id, _cwd = find_most_recent_session("host")
     assert path is None
 
 

--- a/tests/test_opencode_notify.py
+++ b/tests/test_opencode_notify.py
@@ -1,0 +1,36 @@
+"""Tests for lemonaid.opencode.notify module."""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from lemonaid.opencode import notify
+
+
+@contextmanager
+def _fake_connect():
+    yield object()
+
+
+def test_handle_notification_from_event_payload():
+    payload = '{"type":"session.idle","properties":{"sessionID":"ses_abc123"}}'
+
+    with (
+        patch("lemonaid.opencode.notify.db.connect", _fake_connect),
+        patch(
+            "lemonaid.opencode.notify.get_cwd_and_name",
+            return_value=("/tmp/project", "Test Session"),
+        ),
+        patch("lemonaid.opencode.notify.get_tty", return_value="/dev/ttys001"),
+        patch("lemonaid.opencode.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.opencode.notify.get_git_branch", return_value="main"),
+        patch("lemonaid.opencode.notify.db.add") as mock_add,
+    ):
+        notify.handle_notification(stdin_data=payload)
+
+    kwargs = mock_add.call_args.kwargs
+    assert kwargs["channel"] == "opencode:ses_abc123"
+    assert kwargs["name"] == "Test Session"
+    assert kwargs["message"] == "Waiting in tmp/project"
+    assert kwargs["metadata"]["session_id"] == "ses_abc123"
+    assert kwargs["metadata"]["tty"] == "/dev/ttys001"
+    assert kwargs["switch_source"] == "tmux"

--- a/tests/test_opencode_utils.py
+++ b/tests/test_opencode_utils.py
@@ -1,0 +1,52 @@
+"""Tests for lemonaid.opencode.utils module."""
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from lemonaid.opencode import utils
+
+
+def test_get_session_schema_without_data_column(tmp_path: Path):
+    db_path = tmp_path / "opencode.db"
+    session_id = "ses_123"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT)")
+        conn.execute(
+            "INSERT INTO session (id, title, directory) VALUES (?, ?, ?)",
+            (session_id, "My Session", "/tmp/project"),
+        )
+        conn.commit()
+
+    with patch("lemonaid.opencode.utils.get_db_path", return_value=db_path):
+        session = utils._get_session(session_id)
+
+    assert session == {
+        "id": session_id,
+        "title": "My Session",
+        "directory": "/tmp/project",
+        "data": {},
+    }
+
+
+def test_get_cwd_and_name_with_data_column(tmp_path: Path):
+    db_path = tmp_path / "opencode.db"
+    session_id = "ses_456"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, data TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO session (id, title, directory, data) VALUES (?, ?, ?, ?)",
+            (session_id, "Named", "", json.dumps({"path": {"cwd": "/tmp/from-data"}})),
+        )
+        conn.commit()
+
+    with patch("lemonaid.opencode.utils.get_db_path", return_value=db_path):
+        cwd, name = utils.get_cwd_and_name(session_id)
+
+    assert cwd == "/tmp/from-data"
+    assert name == "Named"

--- a/tests/test_opencode_watcher.py
+++ b/tests/test_opencode_watcher.py
@@ -1,0 +1,74 @@
+"""Tests for lemonaid.opencode.watcher module."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from lemonaid.opencode import watcher
+
+
+def test_describe_activity_tool_bash():
+    entry = {
+        "part": {
+            "type": "tool",
+            "tool": "bash",
+            "state": {
+                "input": {
+                    "command": "pytest tests/test_opencode_watcher.py",
+                }
+            },
+        }
+    }
+    assert watcher.describe_activity(entry) == "Running: pytest tests/test_opencode_watcher.py"
+
+
+def test_should_dismiss_user_activity():
+    entry = {"role": "user", "part": {"type": "text", "text": "continue"}}
+    assert watcher.should_dismiss(entry) is True
+
+
+def test_needs_attention_on_step_finish_stop():
+    entry = {"role": "assistant", "part": {"type": "step-finish", "reason": "stop"}}
+    assert watcher.needs_attention(entry) is True
+
+
+def test_needs_attention_false_on_tool_calls_finish():
+    entry = {"role": "assistant", "part": {"type": "step-finish", "reason": "tool-calls"}}
+    assert watcher.needs_attention(entry) is False
+
+
+def test_read_lines_from_sqlite(tmp_path: Path):
+    db_path = tmp_path / "opencode.db"
+    session_id = "ses_test123"
+    message_id = "msg_1"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT, time_created INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)",
+            (message_id, session_id, json.dumps({"role": "assistant"}), 1_700_000_000_000),
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, data, time_created) VALUES (?, ?, ?, ?, ?)",
+            (
+                "prt_1",
+                message_id,
+                session_id,
+                json.dumps({"type": "text", "text": "hello"}),
+                1_700_000_000_123,
+            ),
+        )
+        conn.commit()
+
+    lines = watcher.read_lines(Path(f"{db_path}#{session_id}"))
+    assert len(lines) == 1
+
+    parsed = json.loads(lines[0])
+    assert parsed["role"] == "assistant"
+    assert parsed["part"]["type"] == "text"
+    assert parsed["timestamp"].endswith("Z")

--- a/tests/test_watcher_read_lines.py
+++ b/tests/test_watcher_read_lines.py
@@ -6,8 +6,6 @@ Verifies that:
 - Backends without read_lines fall back to read_jsonl_tail
 """
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path


### PR DESCRIPTION
Adds first-class OpenCode support (notify/dismiss CLI, plugin docs, TUI resume), watcher-driven live activity and unread/read transitions, tmux/session wiring, and OpenCode integration tests. Also updates release metadata and changelog for v0.10.0. Validation: uv run ruff check; uv run pytest.