### PR TITLE
feat: auto-derive tmux session name from directory path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.10.1 (2026-02-23)
+
+#### Changed
+
+- **`tmux new` auto-naming**: Session name is now auto-derived from the last one or two directory components (e.g. `~/play/lemonaid` → `play-lemonaid`). The positional name argument is replaced with `-s` flag, matching tmux's own convention.
+
 # 0.10.0 (2026-02-19)
 
 #### Added

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -54,7 +54,7 @@ Because the swap is atomic, pressing `prefix + p` repeatedly toggles between two
 - `lemonaid tmux back` - Switch to the saved back location
 - `lemonaid tmux swap <session> <pane_id>` - Swap back location and print target (for keybinding integration)
 - `lemonaid tmux scratch` - Toggle the scratch lma pane (see below)
-- `lemonaid tmux new [name]` - Create a new tmux session from a template
+- `lemonaid tmux new [-s name]` - Create a new tmux session from a template
 
 ## Scratch Pane
 
@@ -129,11 +129,12 @@ Each entry in the list creates a window. Empty string means just a shell.
 ### Usage
 
 ```bash
-# Create session named after current directory, using "default" template
+# Create session with auto-derived name from directory path
+# e.g. ~/play/lemonaid -> "play-lemonaid", ~/work/project -> "work-project"
 lemonaid tmux new
 
-# Create session with explicit name
-lemonaid tmux new my-feature
+# Create session with explicit name (like tmux's -s flag)
+lemonaid tmux new -s my-feature
 
 # Use a different template
 lemonaid tmux new --from no-emacs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.10.0"
+version = "0.10.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- `lemonaid tmux new` now auto-derives a ~15-char session name from the last one or two directory components (e.g. `~/play/lemonaid` → `play-lemonaid`, `~/work/project` → `work-project`)
- Replaced positional `name` argument with `-s` flag, matching tmux's own convention
- Single long directory names are used as-is; two components are joined with `-` when they fit within ~15 chars

## Test plan

- [x] All 122 tests pass
- [x] Run `lemonaid tmux new` from various directories and verify session names
- [x] Run `lemonaid tmux new -s custom-name` and verify explicit name works