### PR TITLE
Resume headless sessions from history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 0.11.3 (2026-04-16)
+
+#### Fixed
+
+- **Resume headless and remote-agent sessions**: Sessions started outside tmux/wezterm (e.g. via the Signal bridge, scheduled triggers, remote agents) now surface in the history view (`h`) regardless of read status, since they have no terminal to switch back to. Previously they were stranded in the non-switchable panel with no resume path.
+- **Resume from any directory for agent-started sessions**: `find_session_project` now falls back to scanning `~/.claude/projects/` when a session isn't in `~/.claude/history.jsonl`. Sessions started by remote agents or scheduled triggers never touch history.jsonl, so both lemonaid and `claude --resume` itself couldn't locate them from another cwd.
+
 # 0.11.2 (2026-04-07)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.11.2"
+version = "0.11.3"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/projects.py
+++ b/src/lemonaid/claude/projects.py
@@ -58,11 +58,23 @@ def find_project_path(cwd: str) -> Path | None:
 
 
 def find_session_project(session_id: str) -> str | None:
-    """Look up the project directory for a session via ~/.claude/history.jsonl.
+    """Look up the project directory for a session.
+
+    First tries ~/.claude/history.jsonl (fast, covers interactive sessions).
+    Falls back to scanning ~/.claude/projects/*/<session_id>.jsonl — needed
+    for sessions started by remote agents / scheduled triggers, which never
+    log to history.jsonl.
 
     Returns the project path string, or None if not found.
-    Multiple history entries may exist per session; we take the last one.
     """
+    from_history = _find_in_history(session_id)
+    if from_history:
+        return from_history
+
+    return _find_in_projects(session_id)
+
+
+def _find_in_history(session_id: str) -> str | None:
     if not _HISTORY_PATH.exists():
         _log.warning("history.jsonl not found at %s", _HISTORY_PATH)
         return None
@@ -82,3 +94,39 @@ def find_session_project(session_id: str) -> str | None:
         _log.warning("failed to read history.jsonl: %s", e)
 
     return project
+
+
+def _find_in_projects(session_id: str) -> str | None:
+    """Scan ~/.claude/projects/*/<session_id>.jsonl and read cwd from the transcript.
+
+    The directory name encoding (/ and . both collapse to -) is lossy, so we
+    read the actual cwd from a transcript entry rather than trying to decode.
+    """
+    projects_dir = Path.home() / ".claude" / "projects"
+    if not projects_dir.exists():
+        return None
+
+    for transcript in projects_dir.glob(f"*/{session_id}.jsonl"):
+        cwd = _read_cwd_from_transcript(transcript)
+        if cwd:
+            return cwd
+
+    return None
+
+
+def _read_cwd_from_transcript(transcript: Path) -> str | None:
+    try:
+        with open(transcript) as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                cwd = entry.get("cwd")
+                if cwd:
+                    return cwd
+    except OSError as e:
+        _log.warning("failed to read transcript %s: %s", transcript, e)
+
+    return None

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -184,23 +184,28 @@ def get_history(
     limit: int = 200,
     search: str = "",
 ) -> list[Notification]:
-    """Get archived/read sessions for the history view, newest first.
+    """Get resumable sessions for the history view, newest first.
 
-    Optionally filters by substring match on name, message, channel, cwd, or git_branch.
-    Returns only the most recent notification per channel.
+    Includes archived/read sessions plus headless sessions (switch_source IS NULL)
+    regardless of status — headless sessions have no tmux/wezterm to switch to,
+    so they're only reachable via history. Optionally filters by substring match
+    on name, message, channel, cwd, or git_branch. Returns only the most recent
+    notification per channel.
     """
+    status_cond = "(n.status IN ('archived', 'read') OR n.switch_source IS NULL)"
+    latest_cond = "(status IN ('archived', 'read') OR switch_source IS NULL)"
     if search:
         pattern = f"%{search}%"
         rows = conn.execute(
-            """
+            f"""
             SELECT n.* FROM notifications n
             INNER JOIN (
                 SELECT channel, MAX(id) as max_id
                 FROM notifications
-                WHERE status IN ('archived', 'read')
+                WHERE {latest_cond}
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
-            WHERE n.status IN ('archived', 'read')
+            WHERE {status_cond}
             AND (
                 n.name LIKE ?
                 OR n.message LIKE ?
@@ -215,15 +220,15 @@ def get_history(
         ).fetchall()
     else:
         rows = conn.execute(
-            """
+            f"""
             SELECT n.* FROM notifications n
             INNER JOIN (
                 SELECT channel, MAX(id) as max_id
                 FROM notifications
-                WHERE status IN ('archived', 'read')
+                WHERE {latest_cond}
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
-            WHERE n.status IN ('archived', 'read')
+            WHERE {status_cond}
             ORDER BY n.created_at DESC
             LIMIT ?
             """,

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -367,11 +367,14 @@ class LemonaidApp(App):
             env_filter = self.current_env if self.current_env != "unknown" else None
             # Main table: only sessions switchable from the current environment
             current_notifications = db.get_active(conn, switch_source=env_filter)
-            # Lower pane: everything we can't switch to
+            # Lower pane: live sessions from other switchable terminals.
+            # Headless sessions (switch_source IS NULL) are excluded — they can't be
+            # switched to from anywhere, so they belong in history instead.
             if env_filter:
                 all_notifications = db.get_active(conn, switch_source=None)
                 other_notifications = [
-                    n for n in all_notifications if n.switch_source != env_filter
+                    n for n in all_notifications
+                    if n.switch_source is not None and n.switch_source != env_filter
                 ]
             else:
                 other_notifications = []


### PR DESCRIPTION
## Summary
- Sessions started outside tmux/wezterm (Signal bridge, scheduled triggers, remote agents) now appear in history (`h`) regardless of read status — so they're actually reachable. Previously they sat in the non-switchable panel with no resume binding.
- `find_session_project` falls back to scanning `~/.claude/projects/` when a session isn't in `history.jsonl`. Agent-started sessions never touch history.jsonl, so neither lemonaid nor `claude --resume` itself could locate them from another cwd.

Concrete failing case this unblocks: a Signal-bridge session Peter had about Klein Tools earmuffs was stuck as ``unread`` + ``switch_source=NULL`` — not in the main list (wrong env), not in history (not archived), and the non-switchable panel it was in doesn't handle Enter.

## Test plan
- [x] Existing test suite passes (122 tests).
- [x] Verified on live DB: 12 headless bridge sessions now appear in history; non-switchable panel is empty of them.
- [x] `find_session_project('22f390d1-...')` resolves via projects-dir fallback to `/Users/peter.gaultney/trove`.