### PR TITLE
claude: register sessions as working on UserPromptSubmit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.12.0 (2026-06-08)
+
+#### Added
+
+- **Sessions appear while working**: a new `lemonaid claude submit` hook (wired to Claude Code's `UserPromptSubmit`) registers a session in the inbox the moment you submit a prompt, as a read/working entry. Previously a session was invisible until its first `Stop` or permission prompt, so a long-running turn — especially in auto-accept mode, where permission prompts never fire — wouldn't show up until it paused for input. The registration never reorders or re-flags an existing session (`created_at` is preserved), and a prompt to an archived session brings it back as working.
+
 # 0.11.3 (2026-04-16)
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ Add hooks to `~/.claude/settings.json`:
 ```json
 {
   "hooks": {
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "lemonaid claude submit" }] }],
     "Stop": [{ "hooks": [{ "type": "command", "command": "lemonaid claude notify" }] }],
     "Notification": [{ "matcher": "permission_prompt", "hooks": [{ "type": "command", "command": "lemonaid claude notify" }] }]
   }
 }
 ```
 
-Features: auto-dismiss via transcript watching, live activity updates, binary patch for faster notifications.
+Features: sessions appear in the inbox the moment a prompt is submitted (`UserPromptSubmit`), auto-dismiss via transcript watching, live activity updates, binary patch for faster notifications.
 
 **Full documentation**: [docs/claude.md](docs/claude.md) | [Binary patch](docs/claude-patch.md)
 

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -11,6 +11,16 @@ Add to `~/.claude/settings.json`:
 ```json
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lemonaid claude submit"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -37,17 +47,22 @@ Add to `~/.claude/settings.json`:
 ```
 
 This gives you:
+- **UserPromptSubmit hook**: Registers the session in the inbox the moment you submit a prompt, as a read/working entry (not flagged for attention). This is what makes a session appear while it's still working, rather than only once it stops.
 - **Stop hook**: Notification when Claude finishes responding and is waiting for input
 - **Notification hook**: Notification when Claude needs permission
+
+A session enters the inbox only when a hook fires. Without the `UserPromptSubmit` hook, a session is invisible until its first `Stop` or permission prompt — so a long-running turn (especially in auto-accept mode, where permission prompts never fire) won't show up until it pauses.
 
 ## How it works
 
 ### Notification flow
 
-1. Claude finishes a response (or needs permission)
-2. Claude Code runs `lemonaid claude notify` with session data via stdin
-3. Lemonaid extracts session ID, cwd, and notification type
-4. Notification appears in `lma` inbox with channel `claude:<session_id_prefix>`
+1. You submit a prompt -> Claude Code runs `lemonaid claude submit`, which registers the session as read/working (it appears in the inbox immediately, without being flagged for attention)
+2. Claude finishes a response (or needs permission) -> Claude Code runs `lemonaid claude notify` with session data via stdin
+3. Lemonaid extracts session ID, cwd, and notification type, and flips the session to unread (needs attention)
+4. The notification appears in `lma` inbox with channel `claude:<session_id_prefix>`
+
+The working registration never reorders or re-flags an existing session: a session you're actively driving holds a stable position, and `created_at` (its birth time) is never overwritten. A prompt to an archived session brings it back as a working entry.
 
 ### Auto-dismiss via transcript watching
 
@@ -122,6 +137,8 @@ Add to `~/.claude/settings.json`:
 ```
 
 The `UserPromptSubmit` hook records when you send a message, enabling the elapsed time display. Without this hook, elapsed time won't be shown but everything else still works.
+
+If you also use the `lemonaid claude submit` working-registration hook (above), both commands go in the same `UserPromptSubmit` array as separate entries — they both fire on each submit.
 
 ## Faster notifications
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.11.3"
+version = "0.12.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/cli.py
+++ b/src/lemonaid/claude/cli.py
@@ -3,7 +3,7 @@
 import argparse
 
 from .bootstrap import run_bootstrap
-from .notify import dismiss_session, handle_dismiss, handle_notification
+from .notify import dismiss_session, handle_dismiss, handle_notification, handle_submit
 from .patcher import apply_patch, check_status, find_binary, restore_backup
 from .resume import resume_session
 from .summarize import run_summarize
@@ -12,6 +12,11 @@ from .summarize import run_summarize
 def cmd_notify(args: argparse.Namespace) -> None:
     """Handle Claude Code notification hook."""
     handle_notification()
+
+
+def cmd_submit(args: argparse.Namespace) -> None:
+    """Handle Claude Code UserPromptSubmit hook (register session as working)."""
+    handle_submit()
 
 
 def cmd_dismiss(args: argparse.Namespace) -> None:
@@ -145,6 +150,13 @@ def setup_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Handle notification from Claude Code hook (reads JSON from stdin)",
     )
     notify_parser.set_defaults(func=cmd_notify)
+
+    # claude submit
+    submit_parser = claude_subparsers.add_parser(
+        "submit",
+        help="Register a session as working from a UserPromptSubmit hook (reads JSON from stdin)",
+    )
+    submit_parser.set_defaults(func=cmd_submit)
 
     # claude dismiss
     dismiss_parser = claude_subparsers.add_parser(

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -92,6 +92,70 @@ def get_session_name(session_id: str, cwd: str) -> str | None:
     return None
 
 
+def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str, str | None, dict]:
+    """Resolve the inbox fields shared by the notify and submit hooks.
+
+    Returns (channel, session_id, name, switch_source, metadata).
+    """
+    cwd = data.get("cwd", "unknown")
+    session_id = data.get("session_id", "")
+
+    # Look up session name: Claude name > tmux session name > cwd-derived name
+    name = get_session_name(session_id, cwd) or get_tmux_session_name() or get_name_from_cwd(cwd)
+
+    # Detect switch-source (which terminal environment this notification came from)
+    switch_source = detect_terminal_switch_source()
+
+    metadata = {
+        "cwd": cwd,
+        "session_id": session_id,
+        "notification_type": notification_type,
+    }
+
+    branch = get_git_branch(cwd)
+    if branch:
+        metadata["git_branch"] = branch
+
+    tty = get_tty()  # for pane matching
+    if tty:
+        metadata["tty"] = tty
+
+    return channel_id("claude", session_id), session_id, name, switch_source, metadata
+
+
+def handle_submit(stdin_data: str | None = None) -> None:
+    """Register a session as working in response to a UserPromptSubmit hook.
+
+    Surfaces the session in the inbox the moment a prompt is submitted, as a
+    read/working entry (not flagged for attention). The Stop and Notification
+    hooks flip it to unread when it actually wants the user.
+    """
+    if stdin_data is None:
+        stdin_data = sys.stdin.read()
+
+    _log.info("submit stdin: %s", stdin_data[:200])
+
+    try:
+        data = json.loads(stdin_data) if stdin_data else {}
+    except json.JSONDecodeError:
+        data = {}
+
+    channel, session_id, name, switch_source, metadata = _resolve_session(data, "working")
+    message = f"Working in {shorten_path(data.get('cwd', 'unknown'))}"
+
+    with db.connect() as conn:
+        db.register_working(
+            conn,
+            channel=channel,
+            message=message,
+            name=name,
+            metadata=metadata,
+            switch_source=switch_source if switch_source != "unknown" else None,
+        )
+
+    _log.info("working: channel=%s", channel)
+
+
 def handle_notification(stdin_data: str | None = None) -> None:
     """
     Handle a Claude Code notification from stdin.
@@ -110,7 +174,6 @@ def handle_notification(stdin_data: str | None = None) -> None:
         data = {}
 
     cwd = data.get("cwd", "unknown")
-    session_id = data.get("session_id", "")
     notification_type = data.get("notification_type", "idle_prompt")
 
     # Build message based on notification type
@@ -122,29 +185,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
     else:
         message = f"{notification_type} in {short_path}"
 
-    # Look up session name: Claude name > tmux session name > cwd-derived name
-    name = get_session_name(session_id, cwd) or get_tmux_session_name() or get_name_from_cwd(cwd)
-
-    # Detect switch-source (which terminal environment this notification came from)
-    switch_source = detect_terminal_switch_source()
-
-    # Build metadata for handler
-    metadata = {
-        "cwd": cwd,
-        "session_id": session_id,
-        "notification_type": notification_type,
-    }
-
-    branch = get_git_branch(cwd)
-    if branch:
-        metadata["git_branch"] = branch
-
-    # Try to get TTY for pane matching
-    tty = get_tty()
-    if tty:
-        metadata["tty"] = tty
-
-    channel = channel_id("claude", session_id)
+    channel, session_id, name, switch_source, metadata = _resolve_session(data, notification_type)
 
     # Check existing state before upsert for logging
     with db.connect() as conn:

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -325,6 +325,77 @@ def add(
     )
 
 
+def register_working(
+    conn: sqlite3.Connection,
+    channel: str,
+    message: str,
+    name: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    switch_source: str | None = None,
+) -> Notification:
+    """Register a session that has started working (e.g. on prompt submit).
+
+    Unlike add(), this never flags the session for attention: a brand-new
+    session is inserted as 'read', and an existing session keeps its current
+    status (so a session already 'unread' from a Stop/Notification hook is not
+    silently dismissed, and a 'read' working session is not re-flagged).
+
+    created_at is the session's birth time and is never overwritten on update,
+    so actively-driven sessions hold a stable position rather than churning to
+    the top of the active list on every turn. An archived session reappears as
+    'read' (you're driving it again) but keeps its original created_at.
+    """
+    metadata = metadata or {}
+    existing = get_by_channel(conn, channel, unread_only=False)
+
+    if existing:
+        # Preserve a user-set name the same way add() does.
+        if "auto_name" in existing.metadata:
+            metadata["auto_name"] = existing.metadata["auto_name"]
+            name = existing.name
+
+        new_status = "read" if existing.is_archived else existing.status
+        conn.execute(
+            """
+            UPDATE notifications
+            SET message = ?, name = ?, metadata = ?, switch_source = ?, status = ?
+            WHERE id = ?
+            """,
+            (message, name, json.dumps(metadata), switch_source, new_status, existing.id),
+        )
+        conn.commit()
+        return Notification(
+            id=existing.id,
+            channel=channel,
+            message=message,
+            name=name,
+            metadata=metadata,
+            status=new_status,
+            created_at=existing.created_at,
+            switch_source=switch_source,
+        )
+
+    now = time.time()
+    cursor = conn.execute(
+        """
+        INSERT INTO notifications (channel, message, name, metadata, created_at, switch_source, status)
+        VALUES (?, ?, ?, ?, ?, ?, 'read')
+        """,
+        (channel, message, name, json.dumps(metadata), now, switch_source),
+    )
+    conn.commit()
+    return Notification(
+        id=cursor.lastrowid or 0,
+        channel=channel,
+        message=message,
+        name=name,
+        metadata=metadata,
+        status="read",
+        created_at=now,
+        switch_source=switch_source,
+    )
+
+
 def mark_read(conn: sqlite3.Connection, notification_id: int) -> None:
     """Mark a notification as read."""
     conn.execute(

--- a/tests/test_claude_notify.py
+++ b/tests/test_claude_notify.py
@@ -1,0 +1,52 @@
+"""Tests for lemonaid.claude.notify module."""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from lemonaid.claude import notify
+
+
+@contextmanager
+def _fake_connect():
+    yield object()
+
+
+def test_handle_submit_registers_working():
+    payload = '{"session_id":"abc123","cwd":"/tmp/project","hook_event_name":"UserPromptSubmit"}'
+
+    with (
+        patch("lemonaid.claude.notify.db.connect", _fake_connect),
+        patch("lemonaid.claude.notify.get_session_name", return_value="Test Session"),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys001"),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value="main"),
+        patch("lemonaid.claude.notify.db.register_working") as mock_register,
+    ):
+        notify.handle_submit(stdin_data=payload)
+
+    kwargs = mock_register.call_args.kwargs
+    assert kwargs["channel"] == "claude:abc123"
+    assert kwargs["name"] == "Test Session"
+    assert kwargs["message"] == "Working in tmp/project"
+    assert kwargs["metadata"]["session_id"] == "abc123"
+    assert kwargs["metadata"]["tty"] == "/dev/ttys001"
+    assert kwargs["switch_source"] == "tmux"
+
+
+def test_handle_submit_headless_has_no_switch_source():
+    payload = '{"session_id":"abc123","cwd":"/tmp/project"}'
+
+    with (
+        patch("lemonaid.claude.notify.db.connect", _fake_connect),
+        patch("lemonaid.claude.notify.get_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_name_from_cwd", return_value="project"),
+        patch("lemonaid.claude.notify.get_tty", return_value=None),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="unknown"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value=None),
+        patch("lemonaid.claude.notify.db.register_working") as mock_register,
+    ):
+        notify.handle_submit(stdin_data=payload)
+
+    assert mock_register.call_args.kwargs["switch_source"] is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -178,3 +178,61 @@ def test_notification_from_row():
             assert notification.message == "Test"
             assert notification.name == "my-session"
             assert notification.metadata == {"tty": "/dev/ttys001"}
+
+
+def test_register_working_new_session_is_read():
+    """register_working() inserts a brand-new session as read/working."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "test.db") as conn:
+        n = db.register_working(
+            conn,
+            channel="claude:abc",
+            message="Working in ~/proj",
+            name="proj",
+            switch_source="tmux",
+        )
+        assert n.id > 0
+        assert n.status == "read"
+        assert n.switch_source == "tmux"
+
+
+def test_register_working_preserves_unread_status():
+    """A session already unread (from a Stop hook) is not dismissed by a submit."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "test.db") as conn:
+        db.add(conn, channel="claude:abc", message="Waiting")  # unread
+        n = db.register_working(conn, channel="claude:abc", message="Working")
+        assert n.status == "unread"
+        assert n.message == "Working"
+
+
+def test_register_working_does_not_bump_created_at():
+    """Updating an existing session must not reorder it (created_at unchanged)."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "test.db") as conn:
+        first = db.register_working(conn, channel="claude:abc", message="Working")
+        second = db.register_working(conn, channel="claude:abc", message="Still working")
+        assert second.created_at == first.created_at
+
+
+def test_register_working_unarchives_to_read():
+    """A submit to an archived session brings it back as read, keeping created_at."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "test.db") as conn:
+        created = db.add(
+            conn, channel="claude:abc", message="old", created_at=42, status="archived"
+        )
+        n = db.register_working(conn, channel="claude:abc", message="Working")
+        assert n.status == "read"
+        assert n.created_at == created.created_at == 42
+
+
+def test_register_working_preserves_user_name():
+    """A user-renamed session keeps its name through a working update."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "test.db") as conn:
+        db.add(
+            conn,
+            channel="claude:abc",
+            message="x",
+            name="my-name",
+            metadata={"auto_name": "auto"},
+        )
+        n = db.register_working(conn, channel="claude:abc", message="Working", name="ignored")
+        assert n.name == "my-name"
+        assert n.metadata["auto_name"] == "auto"


### PR DESCRIPTION
A Claude session only entered the lemonaid inbox on its first `Stop` or permission `Notification` hook — both of which mean "it paused for you." In auto-accept mode, permission prompts never fire, so a long-running turn stayed invisible until it actually stopped. There was no "session started working" trigger.

This adds a `lemonaid claude submit` hook for Claude Code's `UserPromptSubmit` event, so a session shows up in the inbox the moment you submit a prompt — as a read/working entry, not flagged for attention.

## Design

A new `db.register_working` primitive, distinct from `add()`, because `add()`'s upsert contract is "something needs attention -> unread," which is the opposite signal:

- new session -> inserted as `read`
- existing `read`/`unread` session -> message/metadata/switch_source updated; **status and `created_at` left untouched** (no attention-flip, no reordering churn on every turn)
- archived session -> reappears as `read`, keeping its original `created_at` (you're driving it again, but it's not a new session)

The `Stop`/`Notification` hooks still flip it to unread when it genuinely wants you.

## Wiring

Add to `~/.claude/settings.json` (a second entry in the `UserPromptSubmit` array, alongside the statusline hook if present):

```json
"UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "lemonaid claude submit" }] }]
```

## Tests

`register_working` (four status transitions + user-name preservation) and `handle_submit` (stdin parse, headless no-switch-source). Full suite green.