### PR TITLE
feat: AI-generated session names in TUI inbox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,20 @@
+# 0.12.2 (2026-07-21)
+
+#### Added
+
+- **AI-generated session names in TUI**: the notify and submit hooks now read `session_name` from Claude Code's hook JSON (the AI-generated conversation title) and use it as a fallback when no custom title or `firstPrompt` is available. Sessions on `main` with generic cwd-derived names now get descriptive titles in the inbox.
+
+#### Changed
+
+- **Statusline: session name no longer truncated**: removed the 30-char truncation on session name display.
+
 # 0.12.1 (2026-07-21)
 
 #### Added
 
 - **Statusline: model name**: shows the current model's display name (e.g. "Opus") dimmed after the context percentage.
 - **Statusline: git dirty indicator**: appends `*` to the branch name when there are uncommitted changes to tracked files.
-- **Statusline: session name**: shows the AI-generated or custom session name (truncated to 30 chars) in dimmed parens at the end.
+- **Statusline: session name**: shows the AI-generated or custom session name in dimmed parens at the end.
 
 # 0.12.0 (2026-06-08)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.12.1"
+version = "0.12.2"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -100,8 +100,13 @@ def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str,
     cwd = data.get("cwd", "unknown")
     session_id = data.get("session_id", "")
 
-    # Look up session name: Claude name > tmux session name > cwd-derived name
-    name = get_session_name(session_id, cwd) or get_tmux_session_name() or get_name_from_cwd(cwd)
+    # Look up session name: Claude name > AI-generated title > tmux session name > cwd-derived name
+    name = (
+        get_session_name(session_id, cwd)
+        or data.get("session_name")
+        or get_tmux_session_name()
+        or get_name_from_cwd(cwd)
+    )
 
     # Detect switch-source (which terminal environment this notification came from)
     switch_source = detect_terminal_switch_source()

--- a/src/lemonaid/claude/statusline.py
+++ b/src/lemonaid/claude/statusline.py
@@ -224,8 +224,6 @@ def render_statusline(data: dict) -> None:
 
     # Session name (custom or AI-generated; absent for default display names)
     session_name = data.get("session_name", "")
-    if session_name and len(session_name) > 30:
-        session_name = session_name[:29] + "..."
     session_part = f" {DIM}({session_name}){RESET}" if session_name else ""
 
     # Build and print status line


### PR DESCRIPTION
🍋:

Uses Claude Code's `session_name` field (the AI-generated conversation title) as a fallback in the name resolution chain for the TUI inbox. The priority is:

1. Custom title / `firstPrompt` from `sessions-index.json`
2. `session_name` from hook JSON (AI-generated)
3. tmux session name
4. cwd-derived name

Sessions on `main` that previously showed as generic directory names now get descriptive titles like "Add model to statusline" from Claude's auto-titling.

Also removes the 30-char truncation on the statusline session name display.