### PR TITLE
Snooze, undo, and session names that actually resolve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+# 0.13.0 (2026-07-30)
+
+#### Added
+
+- **Snooze** (`s`): hold a session out of the inbox until a chosen time - 15 minutes, 1 hour, 4 hours, tomorrow at 9am, or a custom duration (`45m`, `2h`, `3d`; a bare number is minutes). On expiry the session returns with the status it had when snoozed, so snoozing an idle session doesn't manufacture a notification. New agent output cancels a snooze early. `S` opens a snoozed view listing every snoozed session with its wake time; `lemonaid inbox snoozed` shows the same list from the shell.
+- **Undo** (`z`): multi-level undo for inbox state changes - archive, mark-read, snooze, rename. Each action shows a toast naming the affected session, so an accidental archive says what it archived instead of silently removing a row. Actions with effects outside the inbox (switching to a session, resuming one) are deliberately not undoable. History is per-TUI-session and not persisted.
+
+#### Fixed
+
+- **No more scroll flash on refresh**. The inbox rebuilt every row on each one-second tick, which reset the cursor and scroll offset before restoring them a moment later - presenting as the list flashing to the top. Rows are now updated in place when the row set and its order are unchanged (the common case, where only a message or status moved), so the cursor and scroll position never move. A genuine row-set change still rebuilds, and keeps the cursor on its own row by key.
+
+- **Name column sized for real titles**. Now that sessions carry sentence-shaped names, the fixed 14-char Name column truncated nearly all of them. Column widths are responsive: Name takes the largest share of flex space, and narrower terminals drop the columns that earn it least (TTY, then Branch and Message, which CWD largely duplicates) rather than starving Name. At 80 columns Name went from 14 to 39 characters. Rows now fill the terminal width exactly instead of overflowing horizontally.
+
+- **Session names now use Claude's own conversation title**. Claude records the AI-generated name as `type: "ai-title"` entries in the session transcript (and `/rename` as `customTitle`), which lemonaid never read - so sessions kept the tmux worktree or cwd placeholder they were given at first prompt. Two things were wrong: the lookup only consulted `sessions-index.json`, which current Claude versions stopped maintaining (16 of 73 project dirs had one locally, none written in ~6 months), and the stored name was pinned at first sight and never revisited. The lookup now reads the transcript, and a placeholder is upgraded in place once a title exists - both when a hook fires and via a periodic background re-check in the TUI, since titles appear well after a session starts. A user rename still always wins; clearing it restores the newest title rather than the original placeholder.
+
+  A Claude `/rename` takes precedence over the auto-generated title whenever it happened, including on a session that was already auto-titled - the two are now tracked separately, so a rename is recognized rather than being masked by an existing AI title. A name set inside lemonaid (`r`) still outranks both.
+
+  The prior `session_name` hook-payload fallback (0.12.2) was dead code - that field is not present in Claude's hook JSON - and has been removed.
+
 # 0.12.4 (2026-07-22)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The TUI doesn't need to be running for notifications to arrive (hooks write dire
 - **Notification inbox**: Track which [Claude Code](docs/claude.md), [Codex CLI](docs/codex.md), [OpenClaw](docs/openclaw.md), and [OpenCode](docs/opencode.md) sessions need your attention, and what they're doing as they do it
 - **Terminal integration**: Hit enter to jump directly to the waiting session's pane (supports [`tmux`](docs/tmux.md) and [WezTerm](docs/wezterm.md))
 - **Session history & resume**: Browse archived sessions across all projects, filter by name/cwd/branch, and resume directly or copy the command
+- **Snooze**: Hold a session that needs attention "but not yet" until a time you pick, with a snoozed list so nothing goes missing
+- **Undo**: Reverse an accidental archive, mark-read, snooze, or rename - multi-level, with a toast naming what changed
 - **Bootstrap**: `lemonaid claude bootstrap` imports historical Claude sessions from before lemonaid was installed into the archive
 - **Scratch pane** (`tmux`): Toggle an always-on inbox with a keybinding - no startup delay, auto-hides after selection
 - **Auto-refresh TUI**: See new notifications appear without losing your place

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -160,11 +160,28 @@ See [claude-patch.md](claude-patch.md) for details.
 
 ## Session naming
 
-Claude Code sessions can be named with `/rename`. This name appears in the lemonaid inbox. If unnamed, lemonaid derives a name from:
+Claude names a conversation itself once it has some content, writing the name
+into the session transcript as `type: "ai-title"` entries (field `aiTitle`). A
+`/rename` is recorded the same way as `customTitle`. Lemonaid reads the
+transcript and prefers, in order:
 
-1. The session name from `sessions-index.json`
-2. The first user message (truncated)
-3. The working directory name
+1. `customTitle` — your own `/rename`
+2. `aiTitle` — Claude's generated conversation title
+3. A `summary` or `firstPrompt` from `sessions-index.json`, for older sessions
+4. The tmux session name, or the working directory name
+
+None of the first three exist when a session starts, so a new session shows a
+tmux/cwd placeholder and is renamed in place once Claude assigns a title. The TUI
+re-checks unnamed sessions periodically (on a background thread), so a
+long-running session picks up its real name without needing another hook to fire.
+
+A name you set yourself always wins and is never overwritten. Clearing a rename
+(`r`, then empty) restores the latest title Claude has assigned, not the original
+placeholder.
+
+Note on `sessions-index.json`: current Claude versions no longer maintain this
+file, so it only covers sessions from before that change. It remains the source
+for `lemonaid claude bootstrap`, which imports historical sessions.
 
 ## Session files
 
@@ -172,8 +189,8 @@ Claude stores session data in `~/.claude/projects/<encoded_dir>/`:
 
 ```
 ~/.claude/projects/-Users-peter-play-lemonaid/
-  sessions-index.json    # Maps session IDs to names
-  <session_id>.jsonl     # Full conversation history for a session
+  sessions-index.json    # Legacy session index (no longer written by current versions)
+  <session_id>.jsonl     # Full conversation history, including ai-title entries
 ```
 
 The transcript watcher reads these to detect activity and extract tool usage.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -10,6 +10,9 @@ All keybindings in the `lma` TUI are configurable via `~/.config/lemonaid/config
 | `u` | Jump directly to earliest unread session |
 | `m` | Mark as read |
 | `a` | Archive (remove from list) |
+| `s` | Snooze session (pick a duration) |
+| `S` | Toggle snoozed view |
+| `z` | Undo the last inbox change |
 | `r` | Rename session (clear to revert to auto-name) |
 | `h` | Toggle history view |
 | `g` | Refresh |
@@ -26,6 +29,41 @@ All keybindings in the `lma` TUI are configurable via `~/.config/lemonaid/config
 | `/` | Filter by name, cwd, branch |
 | `h` | Exit history |
 
+### Snoozed mode
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Wake the selected session now (returns it to the inbox) |
+| `S` / `q` | Back to the inbox |
+
+## Snooze
+
+`s` holds a session out of the inbox until a time you pick: 15 minutes, 1 hour,
+4 hours, tomorrow morning (9am), or a custom duration (`45m`, `2h`, `3d` — a bare
+number means minutes).
+
+When the timer expires the session returns with the status it had when you
+snoozed it: one that was demanding attention comes back unread, one that was
+merely idle comes back read. Nothing is ever hidden permanently — `S` lists
+every snoozed session with its wake time, and `lemonaid inbox snoozed` shows the
+same list from the shell.
+
+New agent output cancels a snooze early. Snoozing means "not this state, not
+yet"; if the session produces something new, it wants you again.
+
+## Undo
+
+`z` reverses the last change you made to the inbox, and keeps going back through
+earlier ones. Actions that only change a session's state are undoable — archive,
+mark-read, snooze, rename. Actions that reach outside the inbox are not:
+switching to a session and resuming one both do something to your terminal that
+restoring a database row wouldn't take back.
+
+Each undoable action shows a toast naming what it did, so an accidental archive
+tells you what just disappeared instead of leaving you to guess. Undo history
+lives for the lifetime of the TUI session and is not persisted, since a snapshot
+stops being meaningful once other processes have written to the same rows.
+
 ## Configuration
 
 Add a `[tui.keybindings]` section to your config:
@@ -38,6 +76,9 @@ refresh = "g"
 jump_unread = "u"
 mark_read = "m"
 archive = "a"
+snooze = "s"
+snoozed_list = "S"
+undo = "z"
 rename = "r"
 tmux_resume = "T"  # spawn tmux session from history
 up_down = ""  # arrow key alternatives (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.12.4"
+version = "0.13.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -24,6 +24,7 @@ Usage in Claude Code settings.json:
 import json
 import os
 import sys
+import typing as ty
 from pathlib import Path
 
 from ..inbox import db
@@ -41,55 +42,159 @@ from ..log import get_logger
 _log = get_logger("claude.notify")
 
 
-def get_session_name(session_id: str, cwd: str) -> str | None:
-    """Look up the session name from Claude Code's data files.
+_NAME_MAX_LEN = 80
 
-    Checks sessions-index.json first, then falls back to history.jsonl
-    for sessions that haven't been indexed yet.
 
-    Returns customTitle if set, otherwise firstPrompt, otherwise None.
+def _index_entry(session_id: str, cwd: str) -> dict | None:
+    """Find this session's entry in Claude's sessions-index.json.
+
+    Tries the cwd-derived project dir first, then falls back to the parent-path
+    search, which is what finds worktree sessions filed under the main repo.
+    """
+    from .projects import find_project_path, get_project_path
+
+    for project_dir in (get_project_path(cwd), find_project_path(cwd)):
+        if project_dir is None:
+            continue
+
+        index_path = project_dir / "sessions-index.json"
+        if not index_path.exists():
+            continue
+
+        try:
+            data = json.loads(index_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        for entry in data.get("entries", []):
+            if entry.get("sessionId") == session_id:
+                return entry
+
+    return None
+
+
+RENAME_SOURCE = "claude_rename"  # a /rename; final, nothing supersedes it
+TITLE_SOURCE = "claude_index"  # an AI-generated title; a later /rename can win
+
+
+class SessionName(ty.NamedTuple):
+    name: str
+    source: str
+
+
+def _transcript_titles(session_id: str, cwd: str) -> tuple[str | None, str | None]:
+    """Read the newest (customTitle, aiTitle) out of a session's transcript.
+
+    Current Claude versions record the AI-generated conversation name as
+    `type: "ai-title"` entries (field `aiTitle`) in the JSONL transcript, and a
+    `/rename` as `customTitle`. Both are appended as the session progresses, so
+    the last occurrence of each wins and neither exists at first-prompt time.
+
+    sessions-index.json is not consulted here: Claude stopped maintaining it,
+    so it only covers sessions from before that change.
+    """
+    from .projects import find_project_path, get_project_path
+
+    for project_dir in (get_project_path(cwd), find_project_path(cwd)):
+        if project_dir is None:
+            continue
+
+        transcript = project_dir / f"{session_id}.jsonl"
+        if not transcript.exists():
+            continue
+
+        ai_title = None
+        custom_title = None
+        try:
+            with open(transcript, encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    # Cheap reject before paying for a JSON parse; these fields
+                    # appear in a small minority of a large transcript's lines.
+                    if "aiTitle" not in line and "customTitle" not in line:
+                        continue
+
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if title := entry.get("aiTitle"):
+                        ai_title = title
+                    if title := entry.get("customTitle"):
+                        custom_title = title
+        except OSError:
+            continue
+
+        if custom_title or ai_title:
+            return custom_title, ai_title
+
+    return None, None
+
+
+def _history_rename(session_id: str) -> str | None:
+    """Find the most recent `/rename` for a session in history.jsonl."""
+    history_path = Path.home() / ".claude" / "history.jsonl"
+    if not history_path.exists():
+        return None
+
+    rename_name = None
+    try:
+        for line in history_path.read_text().splitlines():
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if entry.get("sessionId") == session_id:
+                display = entry.get("display", "")
+                if display.startswith("/rename "):
+                    rename_name = display[8:].strip()
+    except OSError:
+        return None
+
+    return rename_name
+
+
+def resolve_session_name(session_id: str, cwd: str) -> SessionName | None:
+    """Find the name Claude holds for a session, and say where it came from.
+
+    A `/rename` always wins over the AI-generated title, whenever it happened —
+    including on a session that was already auto-titled. The source is reported
+    so callers can tell a settled name from one an later rename may still
+    supersede.
     """
     if not session_id or not cwd:
         return None
 
-    from .projects import get_project_path
+    custom_title, ai_title = _transcript_titles(session_id, cwd)
+    if custom_title:
+        return SessionName(custom_title, RENAME_SOURCE)
 
-    # Try sessions-index.json first
-    sessions_index_path = get_project_path(cwd) / "sessions-index.json"
-    if sessions_index_path.exists():
-        try:
-            data = json.loads(sessions_index_path.read_text())
-            entries = data.get("entries", [])
+    if rename := _history_rename(session_id):
+        return SessionName(rename, RENAME_SOURCE)
 
-            for entry in entries:
-                if entry.get("sessionId") == session_id:
-                    # Prefer customTitle, fall back to firstPrompt
-                    return entry.get("customTitle") or entry.get("firstPrompt")
+    if ai_title:
+        return SessionName(ai_title, TITLE_SOURCE)
 
-        except (json.JSONDecodeError, OSError):
-            pass
+    entry = _index_entry(session_id, cwd)
+    if entry:
+        if title := entry.get("customTitle"):
+            return SessionName(title, RENAME_SOURCE)
 
-    # Fall back to history.jsonl for sessions not yet indexed
-    # Look for most recent /rename command for this session
-    history_path = Path.home() / ".claude" / "history.jsonl"
-    if history_path.exists():
-        try:
-            rename_name = None
-            for line in history_path.read_text().splitlines():
-                try:
-                    entry = json.loads(line)
-                    if entry.get("sessionId") == session_id:
-                        display = entry.get("display", "")
-                        if display.startswith("/rename "):
-                            rename_name = display[8:].strip()  # Get name after "/rename "
-                except json.JSONDecodeError:
-                    continue
-            if rename_name:
-                return rename_name
-        except OSError:
-            pass
+        if summary := entry.get("summary"):
+            return SessionName(summary, TITLE_SOURCE)
+
+        if prompt := entry.get("firstPrompt"):
+            truncated = prompt[:_NAME_MAX_LEN] + ("..." if len(prompt) > _NAME_MAX_LEN else "")
+            return SessionName(truncated, TITLE_SOURCE)
 
     return None
+
+
+def get_session_name(session_id: str, cwd: str) -> str | None:
+    """The name Claude holds for a session, or None if it has none yet."""
+    resolved = resolve_session_name(session_id, cwd)
+    return resolved.name if resolved else None
 
 
 def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str, str | None, dict]:
@@ -100,13 +205,11 @@ def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str,
     cwd = data.get("cwd", "unknown")
     session_id = data.get("session_id", "")
 
-    # Look up session name: Claude name > AI-generated title > tmux session name > cwd-derived name
-    name = (
-        get_session_name(session_id, cwd)
-        or data.get("session_name")
-        or get_tmux_session_name()
-        or get_name_from_cwd(cwd)
-    )
+    # Claude's own name for the session beats anything we can derive from the
+    # environment; the tmux/cwd names are placeholders until it exists.
+    resolved = resolve_session_name(session_id, cwd)
+    name = resolved.name if resolved else (get_tmux_session_name() or get_name_from_cwd(cwd))
+    name_source = resolved.source if resolved else "environment"
 
     # Detect switch-source (which terminal environment this notification came from)
     switch_source = detect_terminal_switch_source()
@@ -115,6 +218,7 @@ def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str,
         "cwd": cwd,
         "session_id": session_id,
         "notification_type": notification_type,
+        "name_source": name_source,
     }
 
     branch = get_git_branch(cwd)
@@ -179,7 +283,9 @@ def handle_notification(stdin_data: str | None = None) -> None:
         data = {}
 
     cwd = data.get("cwd", "unknown")
-    notification_type = data.get("notification_type") or data.get("hook_event_name") or "idle_prompt"
+    notification_type = (
+        data.get("notification_type") or data.get("hook_event_name") or "idle_prompt"
+    )
 
     short_path = shorten_path(cwd)
     if notification_type == "idle_prompt":

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -68,6 +68,9 @@ class KeybindingsConfig:
     mark_read: str = "m"
     archive: str = "a"
     rename: str = "r"
+    snooze: str = "s"  # Snooze a session out of the inbox for a while
+    snoozed_list: str = "S"  # Toggle the snoozed-sessions view
+    undo: str = "z"  # Undo the last inbox state change
     history: str = "h"  # Toggle history view
     copy_resume: str = "c"  # Copy resume command to clipboard
     tmux_resume: str = "T"  # Spawn tmux session around a history entry

--- a/src/lemonaid/inbox/cli.py
+++ b/src/lemonaid/inbox/cli.py
@@ -87,6 +87,30 @@ def cmd_read(args: argparse.Namespace) -> None:
     print(f"Marked notification {args.id} as read")
 
 
+def cmd_snoozed(args: argparse.Namespace) -> None:
+    """List snoozed sessions and their wake times."""
+    with db.connect() as conn:
+        db.wake_expired(conn)
+        notifications = db.get_snoozed(conn)
+
+    if getattr(args, "json", False):
+        print(json.dumps([_notification_to_json(n) for n in notifications]))
+        return
+
+    if not notifications:
+        print("No snoozed sessions.")
+        return
+
+    for n in notifications:
+        wakes = (
+            datetime.fromtimestamp(n.snooze_until).strftime("%Y-%m-%d %H:%M")
+            if n.snooze_until
+            else "unknown"
+        )
+        name_part = f" ({n.name})" if n.name else ""
+        print(f"[{n.id}] wakes {wakes} | {n.channel}{name_part} | {n.message}")
+
+
 def cmd_purge(args: argparse.Namespace) -> None:
     """Delete old archived/read notifications."""
     with db.connect() as conn:
@@ -138,6 +162,13 @@ def setup_parser(subparsers: argparse._SubParsersAction) -> None:
     read_parser = inbox_subparsers.add_parser("read", help="Mark notification as read")
     read_parser.add_argument("id", type=int, help="Notification ID")
     read_parser.set_defaults(func=cmd_read)
+
+    # inbox snoozed
+    snoozed_parser = inbox_subparsers.add_parser(
+        "snoozed", help="List snoozed sessions and when they wake"
+    )
+    snoozed_parser.add_argument("--json", action="store_true", help="Output as JSON (for lemons)")
+    snoozed_parser.set_defaults(func=cmd_snoozed)
 
     # inbox purge
     purge_parser = inbox_subparsers.add_parser(

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -23,6 +23,8 @@ class Notification:
     created_at: float = field(default_factory=time.time)
     read_at: float | None = None
     switch_source: str | None = None
+    snooze_until: float | None = None
+    snooze_prev_status: str | None = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> Self:
@@ -30,10 +32,16 @@ class Notification:
         # Handle columns which may not exist in older DBs
         switch_source = None
         name = None
+        snooze_until = None
+        snooze_prev_status = None
         with suppress(IndexError, KeyError):
             switch_source = row["switch_source"]
         with suppress(IndexError, KeyError):
             name = row["name"]
+        with suppress(IndexError, KeyError):
+            snooze_until = row["snooze_until"]
+        with suppress(IndexError, KeyError):
+            snooze_prev_status = row["snooze_prev_status"]
 
         return cls(
             id=row["id"],
@@ -45,6 +53,8 @@ class Notification:
             created_at=row["created_at"],
             read_at=row["read_at"],
             switch_source=switch_source,
+            snooze_until=snooze_until,
+            snooze_prev_status=snooze_prev_status,
         )
 
     @property
@@ -58,6 +68,10 @@ class Notification:
     @property
     def is_archived(self) -> bool:
         return self.status == "archived"
+
+    @property
+    def is_snoozed(self) -> bool:
+        return self.status == "snoozed"
 
 
 def get_db_path() -> Path:
@@ -136,11 +150,18 @@ def get_unread(conn: sqlite3.Connection) -> list[Notification]:
     return [Notification.from_row(row) for row in rows]
 
 
+_HIDDEN_STATUSES = ("archived", "snoozed")
+
+
 def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> list[Notification]:
     """Get active sessions (one per channel), unread first then by recency.
 
-    Returns only the most recent notification per channel, excluding archived.
-    If switch_source is provided, filters to only notifications with that exact source.
+    Returns only the most recent notification per channel, excluding archived
+    and snoozed ones. If switch_source is provided, filters to only
+    notifications with that exact source.
+
+    Callers that render the inbox should call wake_expired() first; this query
+    does not itself resurrect sessions whose snooze has run out.
     """
     if switch_source:
         rows = conn.execute(
@@ -149,10 +170,10 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
             INNER JOIN (
                 SELECT channel, MAX(id) as max_id
                 FROM notifications
-                WHERE status != 'archived'
+                WHERE status NOT IN ('archived', 'snoozed')
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
-            WHERE n.status != 'archived'
+            WHERE n.status NOT IN ('archived', 'snoozed')
             AND n.switch_source = ?
             ORDER BY
                 CASE n.status WHEN 'unread' THEN 0 ELSE 1 END,
@@ -167,15 +188,33 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
             INNER JOIN (
                 SELECT channel, MAX(id) as max_id
                 FROM notifications
-                WHERE status != 'archived'
+                WHERE status NOT IN ('archived', 'snoozed')
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
-            WHERE n.status != 'archived'
+            WHERE n.status NOT IN ('archived', 'snoozed')
             ORDER BY
                 CASE n.status WHEN 'unread' THEN 0 ELSE 1 END,
                 n.created_at DESC
             """
         ).fetchall()
+    return [Notification.from_row(row) for row in rows]
+
+
+def get_snoozed(conn: sqlite3.Connection) -> list[Notification]:
+    """Get snoozed sessions, soonest to wake first."""
+    rows = conn.execute(
+        """
+        SELECT n.* FROM notifications n
+        INNER JOIN (
+            SELECT channel, MAX(id) as max_id
+            FROM notifications
+            WHERE status = 'snoozed'
+            GROUP BY channel
+        ) latest ON n.id = latest.max_id
+        WHERE n.status = 'snoozed'
+        ORDER BY n.snooze_until ASC
+        """
+    ).fetchall()
     return [Notification.from_row(row) for row in rows]
 
 
@@ -192,8 +231,12 @@ def get_history(
     on name, message, channel, cwd, or git_branch. Returns only the most recent
     notification per channel.
     """
-    status_cond = "(n.status IN ('archived', 'read') OR n.switch_source IS NULL)"
-    latest_cond = "(status IN ('archived', 'read') OR switch_source IS NULL)"
+    status_cond = (
+        "n.status != 'snoozed' AND (n.status IN ('archived', 'read') OR n.switch_source IS NULL)"
+    )
+    latest_cond = (
+        "status != 'snoozed' AND (status IN ('archived', 'read') OR switch_source IS NULL)"
+    )
     if search:
         pattern = f"%{search}%"
         rows = conn.execute(
@@ -255,6 +298,50 @@ def get_by_channel(
 # --- Mutations ---
 
 
+def _is_backend_name(name_source: Any) -> bool:
+    """Whether a name_source denotes a real backend title rather than a placeholder.
+
+    Placeholders come from the environment (tmux session, cwd). Backend titles
+    come from the agent itself — an AI-generated title or a user's /rename.
+    """
+    return bool(name_source) and name_source != "environment"
+
+
+def _reconcile_name(
+    existing: Notification,
+    name: str | None,
+    metadata: dict[str, Any],
+) -> str | None:
+    """Decide the name to store when re-observing a known session.
+
+    A user rename always wins and is never overwritten. Otherwise the incoming
+    name replaces the stored one, which lets a placeholder derived from tmux or
+    cwd be upgraded once the backend produces a real title. `metadata` is
+    mutated to carry forward the preserved rename bookkeeping.
+    """
+    if "auto_name" in existing.metadata:
+        # The user renamed this session; keep their name. The stored auto-name is
+        # only upgraded by a real backend title, so clearing the override later
+        # restores a good name rather than whatever tmux happened to be called.
+        if name and _is_backend_name(metadata.get("name_source")):
+            metadata["auto_name"] = name
+        else:
+            metadata["auto_name"] = existing.metadata["auto_name"]
+        return existing.name
+
+    if not name:
+        return existing.name
+
+    if not _is_backend_name(metadata.get("name_source")) and _is_backend_name(
+        existing.metadata.get("name_source")
+    ):
+        # Don't regress a real backend title back to a tmux/cwd placeholder.
+        metadata["name_source"] = existing.metadata["name_source"]
+        return existing.name
+
+    return name
+
+
 def add(
     conn: sqlite3.Connection,
     channel: str,
@@ -278,16 +365,13 @@ def add(
         # Look for any existing notification for this channel (including read/archived)
         existing = get_by_channel(conn, channel, unread_only=False)
         if existing:
-            # Preserve user-set name: if auto_name is in existing metadata,
-            # the user renamed this session — keep their name and carry forward auto_name.
-            if "auto_name" in existing.metadata:
-                metadata["auto_name"] = existing.metadata["auto_name"]
-                name = existing.name
+            name = _reconcile_name(existing, name, metadata)
 
             conn.execute(
                 """
                 UPDATE notifications
-                SET message = ?, name = ?, metadata = ?, created_at = ?, status = 'unread', read_at = NULL, switch_source = ?
+                SET message = ?, name = ?, metadata = ?, created_at = ?, status = 'unread', read_at = NULL, switch_source = ?,
+                    snooze_until = NULL, snooze_prev_status = NULL
                 WHERE id = ?
                 """,
                 (message, name, json.dumps(metadata), now, switch_source, existing.id),
@@ -349,10 +433,7 @@ def register_working(
     existing = get_by_channel(conn, channel, unread_only=False)
 
     if existing:
-        # Preserve a user-set name the same way add() does.
-        if "auto_name" in existing.metadata:
-            metadata["auto_name"] = existing.metadata["auto_name"]
-            name = existing.name
+        name = _reconcile_name(existing, name, metadata)
 
         new_status = "read" if existing.is_archived else existing.status
         conn.execute(
@@ -411,14 +492,18 @@ def mark_unread_for_channel(conn: sqlite3.Connection, channel: str) -> int:
     Used when an agent finishes and is waiting for user input.
     Also updates created_at to now, so that should_dismiss() only looks
     at entries after this point (prevents flip-flopping).
+
+    This cancels an active snooze: fresh output means the session wants the user
+    again, and a snooze only defers the state it was applied to.
     Returns count of notifications marked as unread.
     """
     now = time.time()
     cursor = conn.execute(
         """
         UPDATE notifications
-        SET status = 'unread', read_at = NULL, created_at = ?
-        WHERE channel = ? AND status = 'read'
+        SET status = 'unread', read_at = NULL, created_at = ?,
+            snooze_until = NULL, snooze_prev_status = NULL
+        WHERE channel = ? AND status IN ('read', 'snoozed')
         """,
         (now, channel),
     )
@@ -526,6 +611,45 @@ def update_name(
     return cursor.rowcount > 0
 
 
+def refresh_auto_name(
+    conn: sqlite3.Connection,
+    notification_id: int,
+    name: str,
+    name_source: str,
+) -> bool:
+    """Apply a freshly-discovered backend title to a session.
+
+    Backends name a session only after it has run for a while, so the inbox
+    holds a placeholder until then. This upgrades that placeholder without
+    disturbing a name the user set inside lemonaid, which stays visible while its
+    stored auto-name is brought up to date. Returns True if anything changed.
+    """
+    notification = get(conn, notification_id)
+    if not notification or not name:
+        return False
+
+    metadata = dict(notification.metadata)
+    renamed = "auto_name" in metadata
+
+    if renamed:
+        if metadata["auto_name"] == name and metadata.get("name_source") == name_source:
+            return False
+        metadata["auto_name"] = name
+        final_name = notification.name
+    else:
+        if notification.name == name and metadata.get("name_source") == name_source:
+            return False
+        final_name = name
+
+    metadata["name_source"] = name_source
+    conn.execute(
+        "UPDATE notifications SET name = ?, metadata = ? WHERE channel = ?",
+        (final_name, json.dumps(metadata), notification.channel),
+    )
+    conn.commit()
+    return True
+
+
 def mark_read_by_tty(conn: sqlite3.Connection, tty: str) -> int:
     """Mark all unread notifications from a TTY as read."""
     cursor = conn.execute(
@@ -557,6 +681,71 @@ def archive(conn: sqlite3.Connection, notification_id: int) -> None:
             (notification_id,),
         )
     conn.commit()
+
+
+def snooze(conn: sqlite3.Connection, notification_id: int, until: float) -> None:
+    """Hold a session out of the inbox until `until`, then return it as unread.
+
+    Applies to every row on the channel, matching archive()'s scope. The current
+    status is recorded so wake_expired() can tell whether the session was
+    demanding attention when it was snoozed.
+    """
+    row = conn.execute(
+        "SELECT channel, status FROM notifications WHERE id = ?", (notification_id,)
+    ).fetchone()
+    if not row:
+        return
+
+    conn.execute(
+        """
+        UPDATE notifications
+        SET status = 'snoozed', snooze_until = ?, snooze_prev_status = status
+        WHERE channel = ? AND status != 'snoozed'
+        """,
+        (until, row["channel"]),
+    )
+    conn.commit()
+
+
+def unsnooze(conn: sqlite3.Connection, channel: str) -> int:
+    """Return a snoozed channel to the inbox, restoring its pre-snooze status.
+
+    Used both by the expiry sweep and by an explicit un-snooze. Returns the
+    number of rows woken.
+    """
+    cursor = conn.execute(
+        """
+        UPDATE notifications
+        SET status = COALESCE(snooze_prev_status, 'unread'),
+            snooze_until = NULL,
+            snooze_prev_status = NULL
+        WHERE channel = ? AND status = 'snoozed'
+        """,
+        (channel,),
+    )
+    conn.commit()
+    return cursor.rowcount
+
+
+def wake_expired(conn: sqlite3.Connection, now: float | None = None) -> list[str]:
+    """Wake every snoozed session whose timer has passed. Returns woken channels.
+
+    A session that was unread when snoozed comes back unread; one that was
+    merely read comes back read, so snoozing a quiet session doesn't manufacture
+    a notification out of nothing.
+    """
+    now = now if now is not None else time.time()
+    channels = [
+        row["channel"]
+        for row in conn.execute(
+            "SELECT DISTINCT channel FROM notifications WHERE status = 'snoozed' AND snooze_until <= ?",
+            (now,),
+        ).fetchall()
+    ]
+    for channel in channels:
+        unsnooze(conn, channel)
+
+    return channels
 
 
 def clear_old(conn: sqlite3.Connection, days: int = 7) -> int:

--- a/src/lemonaid/inbox/migrations/m004_add_snooze.py
+++ b/src/lemonaid/inbox/migrations/m004_add_snooze.py
@@ -1,0 +1,19 @@
+"""Add snooze support.
+
+A snoozed session is held out of the active inbox until `snooze_until` passes,
+at which point it returns as unread. The status column keeps its own value so a
+waking session can be restored to what it was before the snooze.
+"""
+
+import sqlite3
+
+VERSION = 4
+DESCRIPTION = "Add snooze_until and snooze_prev_status columns"
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    conn.execute("ALTER TABLE notifications ADD COLUMN snooze_until REAL")
+    conn.execute("ALTER TABLE notifications ADD COLUMN snooze_prev_status TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notifications_snooze ON notifications(snooze_until)"
+    )

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -5,7 +5,9 @@ import dataclasses
 import os
 import shlex
 import subprocess
+import threading
 import time
+from collections import abc
 from datetime import datetime
 from typing import cast
 
@@ -27,11 +29,22 @@ from ...lemon_watchers import (
 )
 from ...log import get_logger
 from ...tmux.session import spawn_session_for_resume
-from .. import db
-from .screens import RenameScreen
+from .. import db, undo
+from .screens import RenameScreen, SnoozeScreen, format_wake_time
 from .utils import set_terminal_title, styled_cell
 
 _DAY_SECONDS = 86400
+_NAME_REFRESH_SECONDS = 20  # transcript re-scan cadence for session-name upgrades
+
+_BRANCH_COLUMN = 4
+_MESSAGE_COLUMN = 6
+_TTY_COLUMN = 7
+# Terminal widths at which the weakest columns stop earning their space.
+# Crossing a threshold takes some width back from Name to pay for the column it
+# re-introduces; that trade is intended, and Name stays far above the fixed
+# 14 chars it had before these breakpoints existed.
+_WIDE_LAYOUT_COLS = 132
+_MEDIUM_LAYOUT_COLS = 104
 
 
 _log = get_logger("tui")
@@ -75,6 +88,46 @@ def _build_bindings(keys: str, action: str, label: str, show: bool = True) -> li
     return bindings
 
 
+def _sync_rows(table: DataTable, rows: list[tuple[str, list[Text]]]) -> bool:
+    """Bring a DataTable in line with `rows`, in place where possible.
+
+    `table.clear()` plus re-adding resets the cursor and scroll offset, which
+    reads as the list flashing to the top on every refresh tick. When the row set
+    and its order are unchanged — the common case, where only a message or status
+    moved — cells are updated in place and the cursor never moves.
+
+    Returns True if the table was rebuilt, meaning the caller has to restore the
+    cursor itself. Textual has no public row-reorder API, so a genuine order
+    change still costs a rebuild.
+    """
+    if [str(key.value) for key in table.rows] == [key for key, _ in rows]:
+        for key, cells in rows:
+            row_index = table.get_row_index(key)
+            for column, value in enumerate(cells):
+                table.update_cell_at((row_index, column), value, update_width=False)
+        return False
+
+    table.clear()
+    for key, cells in rows:
+        table.add_row(*cells, key=key)
+
+    return True
+
+
+def _hide_columns(table: DataTable, indices: abc.Container[int], labels: dict[int, str]) -> None:
+    """Collapse the given columns to zero width, restoring the rest.
+
+    Textual's DataTable has no column-visibility flag, so a hidden column is one
+    with no label and no width. `labels` supplies the text to restore.
+    """
+    for i, column in enumerate(table.columns.values()):
+        hidden = i in indices
+        column.label = Text("" if hidden else labels.get(i, ""))
+        if hidden:
+            column.auto_width = False
+            column.width = 0
+
+
 def _stretch_columns(
     table: DataTable,
     flex_specs: list[tuple[int, int, float]],
@@ -92,18 +145,35 @@ def _stretch_columns(
 
     columns = list(table.columns.values())
     flex_indices = {idx for idx, _, _ in flex_specs}
-    padding_total = 2 * table.cell_padding * len(columns) + 1
+    # A hidden column has been collapsed to zero width and draws no padding.
+    hidden = sum(1 for i, c in enumerate(columns) if i not in flex_indices and not c.width)
+    padding_total = 2 * table.cell_padding * (len(columns) - hidden) + 1
     fixed_total = sum(c.width for i, c in enumerate(columns) if i not in flex_indices)
     remaining = total_width - fixed_total - padding_total
     if remaining <= 0:
         return
 
+    # Honour the minimums only while they fit. When the terminal is too narrow
+    # for all of them, fall back to pure proportional division rather than
+    # overflowing the table horizontally.
     total_weight = sum(frac for _, _, frac in flex_specs)
-    for idx, min_w, frac in flex_specs:
-        if idx < len(columns):
-            share = int(remaining * frac / total_weight) if total_weight else min_w
-            columns[idx].auto_width = False
-            columns[idx].width = max(share, min_w)
+    honour_minimums = sum(min_w for _, min_w, _ in flex_specs) <= remaining
+
+    budget = remaining
+    for position, (idx, min_w, frac) in enumerate(flex_specs):
+        if idx >= len(columns):
+            continue
+
+        share = int(remaining * frac / total_weight) if total_weight else min_w
+        width = max(share, min_w) if honour_minimums else share
+        # The last flex column absorbs the rounding remainder so the row fills
+        # the width exactly instead of leaving a ragged gap.
+        if position == len(flex_specs) - 1:
+            width = max(width, budget)
+
+        columns[idx].auto_width = False
+        columns[idx].width = min(width, budget)
+        budget -= columns[idx].width
 
 
 class LemonaidApp(App):
@@ -143,6 +213,10 @@ class LemonaidApp(App):
     #history_table {
         height: 1fr;
     }
+
+    #snoozed_table {
+        height: 1fr;
+    }
     """
 
     def __init__(self, scratch_mode: bool = False) -> None:
@@ -154,7 +228,10 @@ class LemonaidApp(App):
         self._claude_binary = find_binary()
         self._scratch_mode = scratch_mode
         self._history_mode = False
+        self._snoozed_mode = False
         self._history_filter = ""
+        self._undo_stack = undo.Stack()
+        self._last_name_refresh = 0.0
         self._exec_on_exit: tuple[str, list[str]] | None = None
         # Enable ANSI colors for terminal transparency support
         if self.config.tui.transparent:
@@ -189,6 +266,15 @@ class LemonaidApp(App):
         for b in _build_bindings(kb.rename, "rename", "Rename"):
             self.bind(b.key, b.action, description=b.description, show=b.show)
 
+        for b in _build_bindings(kb.snooze, "snooze", "Snooze"):
+            self.bind(b.key, b.action, description=b.description, show=b.show)
+
+        for b in _build_bindings(kb.snoozed_list, "toggle_snoozed", "Snoozed"):
+            self.bind(b.key, b.action, description=b.description, show=b.show)
+
+        for b in _build_bindings(kb.undo, "undo", "Undo"):
+            self.bind(b.key, b.action, description=b.description, show=b.show)
+
         for b in _build_bindings(kb.history, "toggle_history", "History"):
             self.bind(b.key, b.action, description=b.description, show=b.show)
 
@@ -220,6 +306,7 @@ class LemonaidApp(App):
         yield DataTable(id="other_sources_table", show_header=False)
         yield Input(placeholder="Filter by name, cwd, branch...", id="history_filter")
         yield DataTable(id="history_table")
+        yield DataTable(id="snoozed_table")
         yield Static("", id="status")
         yield Footer()
 
@@ -241,10 +328,14 @@ class LemonaidApp(App):
         history_table = self.query_one("#history_table", DataTable)
         self._setup_table(history_table)
 
-        # Hide other sources section and history initially
+        snoozed_table = self.query_one("#snoozed_table", DataTable)
+        self._setup_table(snoozed_table, wake_column=True)
+
+        # Hide other sources section and the alternate views initially
         self.query_one("#other_sources_label", Static).display = False
         other_table.display = False
         history_table.display = False
+        snoozed_table.display = False
         self.query_one("#history_filter", Input).display = False
 
         self._refresh_notifications()
@@ -278,7 +369,6 @@ class LemonaidApp(App):
             self._claude_patch_status = None
             return
 
-        import threading
         from concurrent.futures import ProcessPoolExecutor
 
         binary = self._claude_binary
@@ -310,28 +400,64 @@ class LemonaidApp(App):
         if w <= 0:
             return
 
-        # (column_index, min_width, weight) — same layout for all tables
-        # Name(3), Branch(4), CWD(5), Message(6) are flexible
-        flex = [(3, 12, 0.10), (4, 12, 0.12), (5, 15, 0.15), (6, 25, 0.50)]
-        _stretch_columns(self.query_one("#main_table", DataTable), flex, w)
-        _stretch_columns(self.query_one("#other_sources_table", DataTable), flex, w)
-        _stretch_columns(self.query_one("#history_table", DataTable), flex, w)
+        # Name carries Claude's conversation title, which is what actually
+        # distinguishes one session from another, so it gets the largest share of
+        # flex space. Narrower terminals can't fit every column, and starving
+        # Name to keep the others is the wrong trade: TTY is diagnostic, Branch is
+        # usually inferable from CWD, and Message is mostly "Waiting in <path>",
+        # which CWD already says. They come back as the terminal widens.
+        if w >= _WIDE_LAYOUT_COLS:
+            hidden: set[int] = set()
+            flex = [(3, 40, 0.46), (4, 10, 0.11), (5, 12, 0.13), (6, 16, 0.30)]
+        elif w >= _MEDIUM_LAYOUT_COLS:
+            hidden = {_TTY_COLUMN}
+            flex = [(3, 36, 0.48), (4, 9, 0.10), (5, 11, 0.12), (6, 14, 0.30)]
+        else:
+            hidden = {_TTY_COLUMN, _BRANCH_COLUMN, _MESSAGE_COLUMN}
+            flex = [(3, 30, 0.72), (5, 10, 0.28)]
 
-    def _setup_table(self, table: DataTable) -> None:
+        for table_id in ("#main_table", "#other_sources_table", "#history_table", "#snoozed_table"):
+            table = self.query_one(table_id, DataTable)
+            # The snoozed view's last column is a wake time, not a TTY, and is
+            # the whole point of that view — never hide it.
+            table_hidden = hidden - {_TTY_COLUMN} if table_id == "#snoozed_table" else hidden
+            _hide_columns(table, table_hidden, self._column_labels(table_id))
+            _stretch_columns(table, flex, w)
+
+    def _column_labels(self, table_id: str) -> dict[int, str]:
+        return {
+            0: "Time",
+            3: "Name",
+            _BRANCH_COLUMN: "Branch",
+            5: "CWD",
+            6: "Message",
+            _TTY_COLUMN: "Wakes" if table_id == "#snoozed_table" else "TTY",
+        }
+
+    def _setup_table(self, table: DataTable, wake_column: bool = False) -> None:
         table.cursor_type = "row"
+        # Time holds "HH:MM:SS" or the wider "YYYY-MM-DD" for older sessions.
         table.add_column("Time", width=10)
         table.add_column("", width=1)  # Unread indicator
         table.add_column("", width=3)  # Backend icon
-        table.add_column("Name", width=14)
-        table.add_column("Branch", width=14)
-        table.add_column("CWD", width=25)
+        table.add_column("Name", width=24)
+        table.add_column("Branch", width=12)
+        table.add_column("CWD", width=16)
         table.add_column("Message", width=30)  # Stretched on resize
-        table.add_column("TTY", width=10)
+        # TTY holds "ttysNNN"; the snoozed view's wake label is "Fri 09:00".
+        table.add_column("Wakes" if wake_column else "TTY", width=9 if wake_column else 7)
+
+    def _active_table_id(self) -> str:
+        if self._history_mode:
+            return "#history_table"
+        if self._snoozed_mode:
+            return "#snoozed_table"
+
+        return "#main_table"
 
     def _get_current_row_key(self) -> str | None:
         """Get the row key (notification ID) at current cursor."""
-        table_id = "#history_table" if self._history_mode else "#main_table"
-        table = self.query_one(table_id, DataTable)
+        table = self.query_one(self._active_table_id(), DataTable)
         if table.row_count == 0:
             return None
         try:
@@ -345,10 +471,44 @@ class LemonaidApp(App):
         table = self.query_one("#main_table", DataTable)
         return table.cursor_coordinate.row
 
+    def _active_row(self, n: db.Notification) -> tuple[str, list[Text]]:
+        """Build the main-table row for a session, keyed by notification id."""
+        is_unread = n.is_unread
+        return str(n.id), [
+            styled_cell(_format_timestamp(n.created_at), is_unread),
+            Text("●", style="bold cyan") if is_unread else Text(""),
+            styled_cell(_backend_label(n.channel, self.config.tui.backend_labels), is_unread),
+            styled_cell(n.name or "", is_unread),
+            styled_cell(n.metadata.get("git_branch", ""), is_unread),
+            styled_cell(fish_path(n.metadata.get("cwd", "")), is_unread),
+            styled_cell(n.message, is_unread),
+            styled_cell(n.metadata.get("tty", "").replace("/dev/", ""), is_unread),
+        ]
+
+    def _other_row(self, n: db.Notification) -> tuple[str, list[Text]]:
+        """Build the non-switchable-table row for a session. Always dimmed."""
+        return str(n.id), [
+            Text(_format_timestamp(n.created_at), style="dim"),
+            Text("○", style="dim") if n.is_unread else Text(""),
+            Text(_backend_label(n.channel, self.config.tui.backend_labels), style="dim"),
+            Text(n.name or "", style="dim"),
+            Text(n.metadata.get("git_branch", ""), style="dim cyan"),
+            Text(fish_path(n.metadata.get("cwd", "")), style="dim"),
+            Text(n.message, style="dim"),
+            Text(n.metadata.get("tty", "").replace("/dev/", ""), style="dim"),
+        ]
+
     def _refresh_notifications(self, *, stay_on_unread: bool = False) -> None:
-        # Don't refresh the active inbox while in history mode
-        if self._history_mode:
+        # Alternate views own the screen; the periodic tick still needs to wake
+        # expired snoozes so they're waiting when the inbox comes back.
+        if self._history_mode or self._snoozed_mode:
+            self._wake_expired_snoozes()
+            if self._snoozed_mode:
+                self._refresh_snoozed()
             return
+
+        self._wake_expired_snoozes()
+        self._refresh_session_names()
 
         main_table = self.query_one("#main_table", DataTable)
         other_table = self.query_one("#other_sources_table", DataTable)
@@ -360,9 +520,6 @@ class LemonaidApp(App):
         other_index = other_table.cursor_coordinate.row if other_table.row_count > 0 else 0
         focused_on_other = self.focused is other_table
 
-        main_table.clear()
-        other_table.clear()
-
         with db.connect() as conn:
             env_filter = self.current_env if self.current_env != "unknown" else None
             # Main table: only sessions switchable from the current environment
@@ -373,40 +530,15 @@ class LemonaidApp(App):
             if env_filter:
                 all_notifications = db.get_active(conn, switch_source=None)
                 other_notifications = [
-                    n for n in all_notifications
+                    n
+                    for n in all_notifications
                     if n.switch_source is not None and n.switch_source != env_filter
                 ]
             else:
                 other_notifications = []
 
-        unread_count = 0
-
-        for n in current_notifications:
-            created = _format_timestamp(n.created_at)
-            tty = n.metadata.get("tty", "")
-            if tty:
-                tty = tty.replace("/dev/", "")
-
-            is_unread = n.is_unread
-            if is_unread:
-                unread_count += 1
-
-            indicator = Text("●", style="bold cyan") if is_unread else Text("")
-
-            cwd = fish_path(n.metadata.get("cwd", ""))
-            branch = n.metadata.get("git_branch", "")
-
-            main_table.add_row(
-                styled_cell(created, is_unread),
-                indicator,
-                styled_cell(_backend_label(n.channel, self.config.tui.backend_labels), is_unread),
-                styled_cell(n.name or "", is_unread),
-                styled_cell(branch, is_unread),
-                styled_cell(cwd, is_unread),
-                styled_cell(n.message, is_unread),
-                styled_cell(tty, is_unread),
-                key=str(n.id),
-            )
+        unread_count = sum(1 for n in current_notifications if n.is_unread)
+        rebuilt = _sync_rows(main_table, [self._active_row(n) for n in current_notifications])
 
         # Populate non-switchable table (always dim, not interactive).
         # Hide it if the terminal is too short — main table gets priority.
@@ -420,30 +552,9 @@ class LemonaidApp(App):
             other_label.update("── non-switchable ──")
             other_label.display = True
             other_table.display = True
-
-            for n in other_notifications:
-                created = _format_timestamp(n.created_at)
-                tty = n.metadata.get("tty", "")
-                if tty:
-                    tty = tty.replace("/dev/", "")
-
-                indicator = Text("○", style="dim") if n.is_unread else Text("")
-
-                cwd = fish_path(n.metadata.get("cwd", ""))
-                branch = n.metadata.get("git_branch", "")
-
-                other_table.add_row(
-                    Text(created, style="dim"),
-                    indicator,
-                    Text(_backend_label(n.channel, self.config.tui.backend_labels), style="dim"),
-                    Text(n.name or "", style="dim"),
-                    Text(branch, style="dim cyan"),
-                    Text(cwd, style="dim"),
-                    Text(n.message, style="dim"),
-                    Text(tty, style="dim"),
-                    key=str(n.id),
-                )
+            _sync_rows(other_table, [self._other_row(n) for n in other_notifications])
         else:
+            other_table.clear()
             other_label.display = False
             other_table.display = False
             if focused_on_other:
@@ -453,8 +564,10 @@ class LemonaidApp(App):
         if other_table.row_count > 0:
             other_table.move_cursor(row=min(other_index, other_table.row_count - 1))
 
-        # Restore cursor position
-        if main_table.row_count > 0:
+        # Restore cursor position. An in-place update leaves the cursor where it
+        # was, so only a rebuild (or an explicit jump) needs to move it — moving
+        # it every tick is what made the list flash back to the top.
+        if main_table.row_count > 0 and (rebuilt or stay_on_unread):
             target_index = None
             if stay_on_unread and unread_count > 0:
                 # Stay on an unread item: use current index but cap at last unread
@@ -488,14 +601,82 @@ class LemonaidApp(App):
         """Quit the app, or just hide the pane in scratch mode.
 
         In history mode, q quits directly (use h to return to active view).
+        The snoozed list is a subview, so q backs out of it instead.
         """
+        if self._snoozed_mode:
+            self._set_snoozed_mode(False)
+            return
+
         if self._scratch_mode:
             self._hide_scratch_pane()
         else:
             self.exit()
 
     def action_toggle_history(self) -> None:
+        if self._snoozed_mode:
+            self._set_snoozed_mode(False)
         self._set_history_mode(not self._history_mode)
+
+    def action_toggle_snoozed(self) -> None:
+        if self._history_mode:
+            self._set_history_mode(False)
+        self._set_snoozed_mode(not self._snoozed_mode)
+
+    def _refresh_session_names(self) -> None:
+        """Pull newly-available backend titles into the inbox.
+
+        Claude names a session only once it has some content, so the name in the
+        inbox starts as a tmux/cwd placeholder. Hook fires alone would leave a
+        long-running session stuck with that placeholder, so re-check here.
+
+        Throttled and run off the event loop: resolving a title reads a
+        transcript, which is too slow to do synchronously on every tick.
+        """
+        now = time.time()
+        if now - self._last_name_refresh < _NAME_REFRESH_SECONDS:
+            return
+
+        self._last_name_refresh = now
+        threading.Thread(target=self._scan_session_names, daemon=True).start()
+
+    def _scan_session_names(self) -> None:
+        with db.connect() as conn:
+            candidates = [
+                (n.id, n.metadata.get("session_id", ""), n.metadata.get("cwd", ""))
+                for n in db.get_active(conn, switch_source=None)
+                # Sessions already showing a Claude /rename are settled. Anything
+                # else is re-read: an AI title can still be superseded by a later
+                # /rename, so having one is not a reason to stop looking.
+                if n.channel.startswith("claude:")
+                and n.metadata.get("name_source") != "claude_rename"
+                and n.metadata.get("session_id")
+                and n.metadata.get("cwd")
+            ]
+
+        upgraded = False
+        for notification_id, session_id, cwd in candidates:
+            resolved = claude.notify.resolve_session_name(session_id, cwd)
+            if not resolved:
+                continue
+
+            with db.connect() as conn:
+                if db.refresh_auto_name(conn, notification_id, resolved.name, resolved.source):
+                    upgraded = True
+                    _log.info(
+                        "name upgraded: %d -> %r (%s)",
+                        notification_id,
+                        resolved.name,
+                        resolved.source,
+                    )
+
+        if upgraded:
+            self.call_from_thread(self._refresh_notifications)
+
+    def _wake_expired_snoozes(self) -> None:
+        with db.connect() as conn:
+            woken = db.wake_expired(conn)
+        for channel in woken:
+            _log.info("snooze expired: %s", channel)
 
     def _set_binding_footer(
         self, action: str, *, show: bool | None = None, label: str | None = None
@@ -529,7 +710,7 @@ class LemonaidApp(App):
         history_filter = self.query_one("#history_filter", Input)
 
         # Inbox-only actions
-        for action in ("jump_unread", "mark_read", "archive"):
+        for action in ("jump_unread", "mark_read", "archive", "snooze"):
             self._set_binding_footer(action, show=not enabled)
 
         # History-only actions
@@ -601,6 +782,104 @@ class LemonaidApp(App):
         count = history_table.row_count
         status.update(f"{count} archived session{'s' if count != 1 else ''}")
 
+    def _set_snoozed_mode(self, enabled: bool) -> None:
+        self._snoozed_mode = enabled
+
+        main_table = self.query_one("#main_table", DataTable)
+        snoozed_table = self.query_one("#snoozed_table", DataTable)
+        other_label = self.query_one("#other_sources_label", Static)
+        other_table = self.query_one("#other_sources_table", DataTable)
+
+        # Inbox-only actions don't apply to the snoozed list
+        for action in ("jump_unread", "mark_read", "snooze"):
+            self._set_binding_footer(action, show=not enabled)
+
+        self._set_binding_footer(
+            "toggle_snoozed",
+            label="Exit Snoozed" if enabled else "Snoozed",
+        )
+        self._set_binding_footer("select", label="Wake" if enabled else "Switch")
+        self.refresh_bindings()
+
+        if enabled:
+            self.sub_title = "snoozed"
+            main_table.display = False
+            other_label.display = False
+            other_table.display = False
+            snoozed_table.display = True
+            self._refresh_snoozed()
+            snoozed_table.focus()
+        else:
+            self.sub_title = "attention inbox"
+            snoozed_table.display = False
+            main_table.display = True
+            self._refresh_notifications()
+            main_table.focus()
+
+    def _refresh_snoozed(self) -> None:
+        snoozed_table = self.query_one("#snoozed_table", DataTable)
+        current_row = snoozed_table.cursor_coordinate.row if snoozed_table.row_count > 0 else 0
+
+        with db.connect() as conn:
+            notifications = db.get_snoozed(conn)
+
+        rebuilt = _sync_rows(
+            snoozed_table,
+            [
+                (
+                    str(n.id),
+                    [
+                        Text(_format_timestamp(n.created_at), style="dim"),
+                        Text("○", style="dim") if n.snooze_prev_status == "unread" else Text(""),
+                        Text(
+                            _backend_label(n.channel, self.config.tui.backend_labels), style="dim"
+                        ),
+                        Text(n.name or "", style=""),
+                        Text(n.metadata.get("git_branch", ""), style="dim cyan"),
+                        Text(fish_path(n.metadata.get("cwd", "")), style="dim"),
+                        Text(n.message, style="dim"),
+                        Text(
+                            format_wake_time(n.snooze_until) if n.snooze_until else "",
+                            style="yellow",
+                        ),
+                    ],
+                )
+                for n in notifications
+            ],
+        )
+
+        if rebuilt and snoozed_table.row_count > 0:
+            snoozed_table.move_cursor(row=min(current_row, snoozed_table.row_count - 1))
+
+        count = snoozed_table.row_count
+        self.query_one("#status", Static).update(
+            f"{count} snoozed session{'s' if count != 1 else ''}  |  Enter to wake now"
+        )
+
+    def _wake_selected(self) -> None:
+        """Wake the selected snoozed session and return it to the inbox."""
+        row_key = self._get_current_row_key()
+        if not row_key:
+            return
+
+        with db.connect() as conn:
+            notification = db.get(conn, int(row_key))
+            if not notification:
+                return
+
+            entry = undo.capture(
+                conn,
+                "unsnooze",
+                f'Woke "{notification.name or notification.channel}"',
+                undo.channel_row_ids(conn, notification.id),
+            )
+            db.unsnooze(conn, notification.channel)
+
+        self._undo_stack.push(entry)
+        _log.info("unsnooze: %s", notification.channel)
+        self._refresh_snoozed()
+        self.notify(f"{entry.description} — press {self._undo_key()} to undo")
+
     def _resume_session(self, *, copy_only: bool = False) -> None:
         """Resume the selected history session."""
         history_table = self.query_one("#history_table", DataTable)
@@ -618,7 +897,9 @@ class LemonaidApp(App):
         if not notification:
             return
 
-        resume = resume_mod.build_resume_command(self.config, notification.channel, notification.metadata)
+        resume = resume_mod.build_resume_command(
+            self.config, notification.channel, notification.metadata
+        )
         if not resume:
             self.notify("No cwd metadata — can't build resume command", severity="warning")
             return
@@ -683,7 +964,9 @@ class LemonaidApp(App):
         if not notification:
             return
 
-        resume = resume_mod.build_resume_command(self.config, notification.channel, notification.metadata)
+        resume = resume_mod.build_resume_command(
+            self.config, notification.channel, notification.metadata
+        )
         if not resume:
             self.notify("No cwd metadata — can't build resume command", severity="warning")
             return
@@ -780,11 +1063,17 @@ class LemonaidApp(App):
         table = self._focused_table()
         if self._history_mode and table.id == "history_table":
             self._resume_session()
+        elif self._snoozed_mode and table.id == "snoozed_table":
+            self._wake_selected()
         elif table.id == "main_table":
             table.action_select_cursor()
 
     def action_refresh(self) -> None:
         self._refresh_notifications()
+
+    def _undo_key(self) -> str:
+        keys = self.config.tui.keybindings.undo
+        return keys[0] if keys else "z"
 
     def action_mark_read(self) -> None:
         table = self._focused_table()
@@ -796,9 +1085,19 @@ class LemonaidApp(App):
             notification_id = int(row_key.value)
             with db.connect() as conn:
                 n = db.get(conn, notification_id)
+                if not n:
+                    return
+
+                entry = undo.capture(
+                    conn,
+                    "mark_read",
+                    f'Marked read "{n.name or n.channel}"',
+                    [notification_id],
+                )
                 db.mark_read(conn, notification_id)
-            if n:
-                _log.info("mark_read: %s", n.channel)
+
+            self._undo_stack.push(entry)
+            _log.info("mark_read: %s", n.channel)
             # Keep cursor on unread items when possible
             self._refresh_notifications(stay_on_unread=True)
 
@@ -809,11 +1108,88 @@ class LemonaidApp(App):
             return
 
         row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
-        if row_key:
-            notification_id = int(row_key.value)
+        if not row_key:
+            return
+
+        notification_id = int(row_key.value)
+        with db.connect() as conn:
+            n = db.get(conn, notification_id)
+            if not n:
+                return
+
+            # archive() touches every row on the channel, so snapshot them all.
+            entry = undo.capture(
+                conn,
+                "archive",
+                f'Archived "{n.name or n.channel}"',
+                undo.channel_row_ids(conn, notification_id),
+            )
+            db.archive(conn, notification_id)
+
+        self._undo_stack.push(entry)
+        _log.info("archive: %s", n.channel)
+        self._refresh_notifications()
+        self.notify(f"{entry.description} — press {self._undo_key()} to undo")
+
+    def action_snooze(self) -> None:
+        """Snooze the selected session out of the inbox for a chosen duration."""
+        if self._history_mode or self._snoozed_mode:
+            return
+
+        row_key = self._get_current_row_key()
+        if not row_key:
+            return
+
+        notification_id = int(row_key)
+        with db.connect() as conn:
+            notification = db.get(conn, notification_id)
+
+        if not notification:
+            return
+
+        def handle_snooze(until: float | None) -> None:
+            if until is None:
+                return
+
             with db.connect() as conn:
-                db.archive(conn, notification_id)
+                entry = undo.capture(
+                    conn,
+                    "snooze",
+                    f'Snoozed "{notification.name or notification.channel}" '
+                    f"until {format_wake_time(until)}",
+                    undo.channel_row_ids(conn, notification_id),
+                )
+                db.snooze(conn, notification_id, until)
+
+            self._undo_stack.push(entry)
+            _log.info("snooze: %s until %.0f", notification.channel, until)
             self._refresh_notifications()
+            self.notify(f"{entry.description} — press {self._undo_key()} to undo")
+
+        self.push_screen(
+            SnoozeScreen(session_name=notification.name or ""),
+            handle_snooze,
+        )
+
+    def action_undo(self) -> None:
+        """Reverse the most recent undoable inbox change."""
+        entry = self._undo_stack.pop()
+        if entry is None:
+            self.notify("Nothing to undo", severity="information")
+            return
+
+        with db.connect() as conn:
+            restored = undo.restore(conn, entry)
+
+        _log.info("undo: %s (%d rows)", entry.action, restored)
+        if self._history_mode:
+            self._refresh_history()
+        elif self._snoozed_mode:
+            self._refresh_snoozed()
+        else:
+            self._refresh_notifications()
+
+        self.notify(f"Undid: {entry.description}")
 
     def action_rename(self) -> None:
         """Rename the selected session."""
@@ -834,7 +1210,15 @@ class LemonaidApp(App):
 
             name_to_set = new_name.strip() if new_name.strip() else None
             with db.connect() as conn:
+                entry = undo.capture(
+                    conn,
+                    "rename",
+                    f'Renamed "{notification.name or notification.channel}"',
+                    [notification_id],
+                )
                 db.update_name(conn, notification_id, name_to_set)
+
+            self._undo_stack.push(entry)
             if self._history_mode:
                 self._refresh_history()
             else:
@@ -953,6 +1337,10 @@ class LemonaidApp(App):
         """
         if event.data_table.id == "history_table":
             self._resume_session()
+            return
+
+        if event.data_table.id == "snoozed_table":
+            self._wake_selected()
             return
 
         if event.data_table.id != "main_table":

--- a/src/lemonaid/inbox/tui/screens.py
+++ b/src/lemonaid/inbox/tui/screens.py
@@ -1,9 +1,164 @@
 """Modal screens for the TUI."""
 
+import time
+import typing as ty
+from datetime import datetime, timedelta
+
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Input, Label
+from textual.widgets import Input, Label, OptionList
+from textual.widgets.option_list import Option
+
+_MORNING_HOUR: ty.Final = 9
+
+
+def next_morning(now: float) -> float:
+    """The next 9am strictly after `now`."""
+    dt = datetime.fromtimestamp(now)
+    target = dt.replace(hour=_MORNING_HOUR, minute=0, second=0, microsecond=0)
+    if target <= dt:
+        target += timedelta(days=1)
+
+    return target.timestamp()
+
+
+def parse_duration(text: str) -> float | None:
+    """Parse a relative duration like '45m', '2h', '3d' into seconds.
+
+    A bare number is read as minutes. Returns None if unparseable or not
+    positive, which the caller surfaces rather than snoozing by accident.
+    """
+    text = text.strip().lower()
+    if not text:
+        return None
+
+    units = {"m": 60, "h": 3600, "d": 86400}
+    multiplier = 60
+    if text[-1] in units:
+        multiplier = units[text[-1]]
+        text = text[:-1]
+
+    try:
+        value = float(text)
+    except ValueError:
+        return None
+
+    return value * multiplier if value > 0 else None
+
+
+def format_wake_time(until: float, now: float | None = None) -> str:
+    """Render a wake time as a short human label (e.g. '14:30', 'Fri 09:00')."""
+    now = now if now is not None else time.time()
+    dt = datetime.fromtimestamp(until)
+    if dt.date() == datetime.fromtimestamp(now).date():
+        return dt.strftime("%H:%M")
+
+    return dt.strftime("%a %H:%M")
+
+
+class SnoozeScreen(ModalScreen[float | None]):
+    """Duration picker for snoozing a session.
+
+    Dismisses with an absolute wake timestamp, or None on cancel.
+    """
+
+    CSS = """
+    SnoozeScreen {
+        align: center middle;
+    }
+
+    SnoozeScreen > Vertical {
+        width: 52;
+        height: auto;
+        padding: 1 2;
+        background: $surface;
+        border: thick $primary;
+    }
+
+    SnoozeScreen Label {
+        width: 100%;
+        text-align: center;
+        padding-bottom: 1;
+    }
+
+    SnoozeScreen OptionList {
+        height: auto;
+        max-height: 10;
+    }
+
+    SnoozeScreen Input {
+        width: 100%;
+        display: none;
+    }
+
+    SnoozeScreen .custom Input {
+        display: block;
+    }
+
+    SnoozeScreen .hint {
+        color: $text-muted;
+        text-style: italic;
+        padding-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    # (id, label, seconds from now) — None seconds means a computed/custom target.
+    _PRESETS: ty.Final = (
+        ("15m", "15 minutes", 15 * 60),
+        ("1h", "1 hour", 3600),
+        ("4h", "4 hours", 4 * 3600),
+        ("morning", "Tomorrow morning (9am)", None),
+        ("custom", "Custom...", None),
+    )
+
+    def __init__(self, session_name: str = "") -> None:
+        super().__init__()
+        self.session_name = session_name
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label(f"Snooze {self.session_name}".strip())
+            yield OptionList(
+                *[Option(label, id=key) for key, label, _ in self._PRESETS],
+                id="snooze-options",
+            )
+            yield Input(placeholder="e.g. 45m, 2h, 3d", id="snooze-custom")
+            yield Label("Enter to pick, Escape to cancel", classes="hint")
+
+    def on_mount(self) -> None:
+        self.query_one("#snooze-options", OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        key = event.option.id
+        if key == "custom":
+            self.query_one(Vertical).add_class("custom")
+            self.query_one("#snooze-custom", Input).focus()
+            return
+
+        if key == "morning":
+            self.dismiss(next_morning(time.time()))
+            return
+
+        for preset_key, _, seconds in self._PRESETS:
+            if preset_key == key and seconds is not None:
+                self.dismiss(time.time() + seconds)
+                return
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        seconds = parse_duration(event.value)
+        if seconds is None:
+            self.notify("Enter a duration like 45m, 2h, or 3d", severity="warning")
+            return
+
+        self.dismiss(time.time() + seconds)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
 
 class RenameScreen(ModalScreen[str | None]):

--- a/src/lemonaid/inbox/undo.py
+++ b/src/lemonaid/inbox/undo.py
@@ -1,0 +1,128 @@
+"""Undo stack for inbox state changes.
+
+Only mutations confined to the inbox are undoable: archive, mark-read, snooze,
+rename. Actions with effects outside the database (switching to a session,
+spawning a resume) are not, because reversing the row would not reverse what
+already happened in the terminal.
+
+An entry snapshots the affected rows before the mutation, so undo restores
+exactly the prior state rather than inferring it. Snapshots are taken per-row
+because archive() and snooze() act on every row sharing a channel, and those
+rows may not have shared a status.
+"""
+
+import sqlite3
+import typing as ty
+
+_MAX_DEPTH: ty.Final = 50
+
+_UNDOABLE_COLUMNS: ty.Final = (
+    "status",
+    "read_at",
+    "created_at",
+    "name",
+    "metadata",
+    "snooze_until",
+    "snooze_prev_status",
+)
+
+
+class _RowSnapshot(ty.NamedTuple):
+    notification_id: int
+    values: tuple[ty.Any, ...]
+
+
+class Entry(ty.NamedTuple):
+    """One undoable action: what it was, what to show, and how to reverse it."""
+
+    action: str
+    description: str
+    rows: tuple[_RowSnapshot, ...]
+
+
+def _snapshot_rows(conn: sqlite3.Connection, ids: ty.Iterable[int]) -> tuple[_RowSnapshot, ...]:
+    columns = ", ".join(_UNDOABLE_COLUMNS)
+    snapshots = []
+    for notification_id in ids:
+        row = conn.execute(
+            f"SELECT {columns} FROM notifications WHERE id = ?", (notification_id,)
+        ).fetchone()
+        if row:
+            snapshots.append(
+                _RowSnapshot(notification_id, tuple(row[c] for c in _UNDOABLE_COLUMNS))
+            )
+
+    return tuple(snapshots)
+
+
+def channel_row_ids(conn: sqlite3.Connection, notification_id: int) -> list[int]:
+    """All row ids sharing the channel of `notification_id`, including itself.
+
+    Channel-wide mutations need this to snapshot everything they will touch.
+    """
+    row = conn.execute(
+        "SELECT channel FROM notifications WHERE id = ?", (notification_id,)
+    ).fetchone()
+    if not row:
+        return [notification_id]
+
+    return [
+        r["id"]
+        for r in conn.execute(
+            "SELECT id FROM notifications WHERE channel = ?", (row["channel"],)
+        ).fetchall()
+    ]
+
+
+def capture(
+    conn: sqlite3.Connection,
+    action: str,
+    description: str,
+    ids: ty.Iterable[int],
+) -> Entry:
+    """Snapshot rows before a mutation. Call this *before* mutating them."""
+    return Entry(action=action, description=description, rows=_snapshot_rows(conn, ids))
+
+
+def restore(conn: sqlite3.Connection, entry: Entry) -> int:
+    """Restore the rows in `entry` to their snapshotted state. Returns rows changed."""
+    assignments = ", ".join(f"{c} = ?" for c in _UNDOABLE_COLUMNS)
+    changed = 0
+    for snapshot in entry.rows:
+        cursor = conn.execute(
+            f"UPDATE notifications SET {assignments} WHERE id = ?",
+            (*snapshot.values, snapshot.notification_id),
+        )
+        changed += cursor.rowcount
+    conn.commit()
+    return changed
+
+
+class Stack:
+    """Bounded LIFO of undoable actions.
+
+    Held in memory for the lifetime of a TUI session; undo history is
+    deliberately not persisted, since a snapshot's meaning decays once other
+    processes have written to the same rows.
+    """
+
+    def __init__(self, max_depth: int = _MAX_DEPTH) -> None:
+        self._entries: list[Entry] = []
+        self._max_depth = max_depth
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def push(self, entry: Entry) -> None:
+        if not entry.rows:
+            return
+
+        self._entries.append(entry)
+        if len(self._entries) > self._max_depth:
+            del self._entries[0]
+
+    def peek(self) -> Entry | None:
+        return self._entries[-1] if self._entries else None
+
+    def pop(self) -> Entry | None:
+        return self._entries.pop() if self._entries else None

--- a/tests/test_claude_notify.py
+++ b/tests/test_claude_notify.py
@@ -16,7 +16,10 @@ def test_handle_submit_registers_working():
 
     with (
         patch("lemonaid.claude.notify.db.connect", _fake_connect),
-        patch("lemonaid.claude.notify.get_session_name", return_value="Test Session"),
+        patch(
+            "lemonaid.claude.notify.resolve_session_name",
+            return_value=notify.SessionName("Test Session", notify.TITLE_SOURCE),
+        ),
         patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
         patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys001"),
         patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
@@ -39,7 +42,7 @@ def test_handle_submit_headless_has_no_switch_source():
 
     with (
         patch("lemonaid.claude.notify.db.connect", _fake_connect),
-        patch("lemonaid.claude.notify.get_session_name", return_value=None),
+        patch("lemonaid.claude.notify.resolve_session_name", return_value=None),
         patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
         patch("lemonaid.claude.notify.get_name_from_cwd", return_value="project"),
         patch("lemonaid.claude.notify.get_tty", return_value=None),

--- a/tests/test_column_layout.py
+++ b/tests/test_column_layout.py
@@ -1,0 +1,104 @@
+"""Tests for responsive column sizing in the inbox tables."""
+
+import asyncio
+
+from rich.text import Text
+
+from lemonaid.inbox.tui.app import (
+    _MEDIUM_LAYOUT_COLS,
+    _WIDE_LAYOUT_COLS,
+    LemonaidApp,
+)
+
+
+def _widths(width: int) -> dict[str, int]:
+    """Run the app at a given terminal width and return visible column widths."""
+
+    async def run() -> dict[str, int]:
+        app = LemonaidApp()
+        async with app.run_test(size=(width, 26)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            table = app.query_one("#main_table")
+            return {
+                c.label.plain: c.width for c in table.columns.values() if c.width and c.label.plain
+            }
+
+    return asyncio.run(run())
+
+
+def _row_width(width: int) -> int:
+    async def run() -> int:
+        app = LemonaidApp()
+        async with app.run_test(size=(width, 26)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            table = app.query_one("#main_table")
+            visible = [c for c in table.columns.values() if c.width]
+            return sum(c.width for c in visible) + 2 * table.cell_padding * len(visible) + 1
+
+    return asyncio.run(run())
+
+
+def test_row_never_exceeds_terminal_width():
+    """Overflowing the width would scroll the table horizontally."""
+    for width in (60, 80, 96, 100, 120, 160, 200):
+        assert _row_width(width) <= width, width
+
+
+def test_narrow_layout_drops_weakest_columns_for_name():
+    """At 80 columns Name matters more than TTY, Branch, or Message."""
+    widths = _widths(80)
+    assert "TTY" not in widths
+    assert "Branch" not in widths
+    assert "Message" not in widths
+    assert widths["Name"] > 30
+
+
+def test_medium_layout_keeps_message_but_not_tty():
+    widths = _widths(_MEDIUM_LAYOUT_COLS)
+    assert "TTY" not in widths
+    assert "Message" in widths
+    assert "Branch" in widths
+
+
+def test_wide_layout_shows_every_column():
+    widths = _widths(_WIDE_LAYOUT_COLS)
+    assert {"Time", "Name", "Branch", "CWD", "Message", "TTY"} <= set(widths)
+
+
+def test_name_grows_with_width_within_a_layout():
+    """Name is not strictly monotonic across layout thresholds.
+
+    Crossing a threshold re-introduces a column (Message at the medium
+    threshold, TTY at the wide one), which necessarily takes space back from
+    Name. That trade is deliberate, so growth is only asserted within a layout.
+    """
+    assert _widths(60)["Name"] < _widths(80)["Name"] < _widths(_MEDIUM_LAYOUT_COLS - 1)["Name"]
+    assert _widths(_MEDIUM_LAYOUT_COLS)["Name"] < _widths(_WIDE_LAYOUT_COLS - 1)["Name"]
+    assert _widths(_WIDE_LAYOUT_COLS)["Name"] < _widths(200)["Name"]
+
+
+def test_name_beats_original_fixed_width_everywhere():
+    """The whole point of the change: Name is never back to its old 14 chars."""
+    for width in (60, 80, 100, _MEDIUM_LAYOUT_COLS, 120, _WIDE_LAYOUT_COLS, 160, 200):
+        assert _widths(width)["Name"] >= 24, width
+
+
+def test_name_is_widest_flex_column_when_wide():
+    widths = _widths(160)
+    assert widths["Name"] > widths["Message"]
+    assert widths["Name"] > widths["CWD"]
+
+
+def test_snoozed_table_keeps_its_wake_column_when_narrow():
+    """The wake time is the point of the snoozed view, unlike a TTY."""
+
+    async def run() -> Text:
+        app = LemonaidApp()
+        async with app.run_test(size=(80, 26)) as pilot:
+            await pilot.pause()
+            table = app.query_one("#snoozed_table")
+            return list(table.columns.values())[7].label
+
+    assert asyncio.run(run()).plain == "Wakes"

--- a/tests/test_row_sync.py
+++ b/tests/test_row_sync.py
@@ -1,0 +1,112 @@
+"""Tests for in-place table updates.
+
+Rebuilding the table on every refresh tick reset the cursor and scroll offset,
+which presented as the row list flashing to the top once a second.
+"""
+
+import asyncio
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+from lemonaid.inbox.tui.app import _sync_rows
+
+
+class _TableApp(App):
+    def compose(self) -> ComposeResult:
+        yield DataTable()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.add_column("a")
+        table.add_column("b")
+
+
+def _rows(*specs: tuple[str, str]) -> list[tuple[str, list[Text]]]:
+    return [(key, [Text(key), Text(value)]) for key, value in specs]
+
+
+def _run(body):
+    async def main():
+        app = _TableApp()
+        async with app.run_test(size=(40, 10)) as pilot:
+            await pilot.pause()
+            return await body(app.query_one(DataTable), pilot)
+
+    return asyncio.run(main())
+
+
+def test_same_row_set_updates_in_place():
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "one"), ("2", "two")))
+        await pilot.pause()
+        rebuilt = _sync_rows(table, _rows(("1", "ONE"), ("2", "two")))
+        return rebuilt, table.get_row("1")[1].plain, table.row_count
+
+    rebuilt, cell, count = _run(body)
+    assert rebuilt is False
+    assert cell == "ONE"
+    assert count == 2
+
+
+def test_cursor_survives_in_place_update():
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "a"), ("2", "b"), ("3", "c")))
+        await pilot.pause()
+        table.move_cursor(row=2)
+        await pilot.pause()
+        _sync_rows(table, _rows(("1", "a"), ("2", "CHANGED"), ("3", "c")))
+        await pilot.pause()
+        return table.cursor_coordinate.row
+
+    assert _run(body) == 2
+
+
+def test_changed_row_set_rebuilds():
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "a"), ("2", "b")))
+        await pilot.pause()
+        rebuilt = _sync_rows(table, _rows(("1", "a"), ("2", "b"), ("3", "c")))
+        return rebuilt, table.row_count
+
+    rebuilt, count = _run(body)
+    assert rebuilt is True
+    assert count == 3
+
+
+def test_reorder_counts_as_a_rebuild():
+    """Row order carries meaning (unread first), so a reorder must be applied."""
+
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "a"), ("2", "b")))
+        await pilot.pause()
+        rebuilt = _sync_rows(table, _rows(("2", "b"), ("1", "a")))
+        return rebuilt, [str(k.value) for k in table.rows]
+
+    rebuilt, order = _run(body)
+    assert rebuilt is True
+    assert order == ["2", "1"]
+
+
+def test_removal_is_applied():
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "a"), ("2", "b")))
+        await pilot.pause()
+        _sync_rows(table, _rows(("1", "a")))
+        return table.row_count, [str(k.value) for k in table.rows]
+
+    count, order = _run(body)
+    assert count == 1
+    assert order == ["1"]
+
+
+def test_empty_target_clears_table():
+    async def body(table, pilot):
+        _sync_rows(table, _rows(("1", "a")))
+        await pilot.pause()
+        _sync_rows(table, [])
+        return table.row_count
+
+    assert _run(body) == 0

--- a/tests/test_session_naming.py
+++ b/tests/test_session_naming.py
@@ -1,0 +1,328 @@
+"""Tests for Claude session-name resolution and name upgrades.
+
+The bug these cover: Claude writes an AI-generated `summary` into
+sessions-index.json only after a session has some content, so the first hook
+fire legitimately sees only `firstPrompt` (or nothing at all, falling back to a
+tmux/cwd placeholder). A later fire must be able to upgrade the stored name.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from lemonaid.claude import notify
+from lemonaid.inbox import db
+
+_SESSION = "abc12345-0000-0000-0000-000000000000"
+
+
+def _write_index(project_dir: Path, entry: dict) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "sessions-index.json").write_text(json.dumps({"entries": [entry]}))
+
+
+def _patch_home(monkeypatch, home: Path) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+
+
+def test_prefers_summary_over_first_prompt(monkeypatch, tmp_path):
+    """The AI-generated summary is the name we actually want in the inbox."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    _write_index(
+        tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid",
+        {
+            "sessionId": _SESSION,
+            "firstPrompt": "please go fix the thing that is broken somehow",
+            "summary": "Fix broken notification hook",
+        },
+    )
+
+    assert notify.get_session_name(_SESSION, cwd) == "Fix broken notification hook"
+
+
+def test_custom_title_beats_summary(monkeypatch, tmp_path):
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    _write_index(
+        tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid",
+        {
+            "sessionId": _SESSION,
+            "customTitle": "my-name",
+            "summary": "Fix broken notification hook",
+            "firstPrompt": "whatever",
+        },
+    )
+
+    assert notify.get_session_name(_SESSION, cwd) == "my-name"
+
+
+def test_falls_back_to_truncated_first_prompt(monkeypatch, tmp_path):
+    """Before a summary exists, the first prompt is the best available name."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    _write_index(
+        tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid",
+        {"sessionId": _SESSION, "firstPrompt": "z" * 200},
+    )
+
+    name = notify.get_session_name(_SESSION, cwd)
+    assert name is not None
+    assert name.endswith("...")
+    assert len(name) == notify._NAME_MAX_LEN + 3
+
+
+def test_no_index_yields_none(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    assert notify.get_session_name(_SESSION, "/Users/x/play/lemonaid") is None
+
+
+def test_environment_name_upgraded_by_real_title():
+    """A tmux/cwd placeholder is replaced once Claude produces a summary."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="play-lemonaid",
+            metadata={"name_source": "environment"},
+        )
+        updated = db.add(
+            conn,
+            channel="claude:abc",
+            message="Waiting",
+            name="Fix broken notification hook",
+            metadata={"name_source": "claude_index"},
+        )
+
+        assert updated.name == "Fix broken notification hook"
+
+
+def test_real_title_not_regressed_to_placeholder():
+    """Once a real title is stored, a later environment name must not clobber it."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        db.add(
+            conn,
+            channel="claude:abc",
+            message="Waiting",
+            name="Fix broken notification hook",
+            metadata={"name_source": "claude_index"},
+        )
+        updated = db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="play-lemonaid",
+            metadata={"name_source": "environment"},
+        )
+
+        assert updated.name == "Fix broken notification hook"
+
+
+def test_user_rename_survives_name_upgrade():
+    """A rename always wins, but the tracked auto-name still improves."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        n = db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="play-lemonaid",
+            metadata={"name_source": "environment"},
+        )
+        db.update_name(conn, n.id, "my-own-name")
+
+        updated = db.add(
+            conn,
+            channel="claude:abc",
+            message="Waiting",
+            name="Fix broken notification hook",
+            metadata={"name_source": "claude_index"},
+        )
+        assert updated.name == "my-own-name"
+        assert updated.metadata["auto_name"] == "Fix broken notification hook"
+
+        # Clearing the override restores the upgraded auto-name, not the placeholder.
+        db.update_name(conn, n.id, None)
+        cleared = db.get(conn, n.id)
+        assert cleared is not None
+        assert cleared.name == "Fix broken notification hook"
+
+
+def test_refresh_auto_name_upgrades_placeholder():
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        n = db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="play-lemonaid",
+            metadata={"name_source": "environment"},
+        )
+
+        assert db.refresh_auto_name(conn, n.id, "Add snooze function", notify.TITLE_SOURCE) is True
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.name == "Add snooze function"
+        assert after.metadata["name_source"] == notify.TITLE_SOURCE
+
+        # Idempotent: re-applying the same title changes nothing.
+        assert db.refresh_auto_name(conn, n.id, "Add snooze function", notify.TITLE_SOURCE) is False
+
+
+def test_rename_supersedes_an_existing_ai_title():
+    """A /rename after Claude auto-titled the session must win."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        n = db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="Audit code for intermittent user issue",
+            metadata={"name_source": notify.TITLE_SOURCE},
+        )
+
+        assert db.refresh_auto_name(conn, n.id, "annoying-refresh", notify.RENAME_SOURCE) is True
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.name == "annoying-refresh"
+        assert after.metadata["name_source"] == notify.RENAME_SOURCE
+
+
+def test_refresh_auto_name_keeps_user_rename():
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        n = db.add(conn, channel="claude:abc", message="Working", name="play-lemonaid")
+        db.update_name(conn, n.id, "my-own-name")
+
+        assert db.refresh_auto_name(conn, n.id, "Add snooze function", notify.TITLE_SOURCE) is True
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.name == "my-own-name"
+        assert after.metadata["auto_name"] == "Add snooze function"
+
+
+def test_refresh_auto_name_ignores_empty_title():
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        n = db.add(conn, channel="claude:abc", message="Working", name="play-lemonaid")
+
+        assert db.refresh_auto_name(conn, n.id, "", notify.TITLE_SOURCE) is False
+        assert db.get(conn, n.id).name == "play-lemonaid"  # type: ignore[union-attr]
+
+
+def test_transcript_ai_title_wins_over_index(tmp_path, monkeypatch):
+    """Current Claude records names in the transcript, not sessions-index.json."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    _write_index(project, {"sessionId": _SESSION, "summary": "stale index summary"})
+    (project / f"{_SESSION}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "cwd": cwd}),
+                json.dumps({"type": "ai-title", "aiTitle": "First guess"}),
+                json.dumps({"type": "ai-title", "aiTitle": "Refined title"}),
+            ]
+        )
+    )
+
+    assert notify.get_session_name(_SESSION, cwd) == "Refined title"
+
+
+def test_transcript_custom_title_wins_over_ai_title(tmp_path, monkeypatch):
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    project.mkdir(parents=True)
+    (project / f"{_SESSION}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "ai-title", "aiTitle": "Generated"}),
+                json.dumps({"type": "custom-title", "customTitle": "my-rename"}),
+            ]
+        )
+    )
+
+    assert notify.get_session_name(_SESSION, cwd) == "my-rename"
+
+
+def test_rename_wins_even_when_ai_title_comes_later(tmp_path, monkeypatch):
+    """Claude keeps emitting ai-title entries after a /rename; the rename still wins."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    project.mkdir(parents=True)
+    (project / f"{_SESSION}.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "custom-title", "customTitle": "my-rename"}),
+                json.dumps({"type": "ai-title", "aiTitle": "Generated later"}),
+            ]
+        )
+    )
+
+    resolved = notify.resolve_session_name(_SESSION, cwd)
+    assert resolved is not None
+    assert resolved.name == "my-rename"
+    assert resolved.source == notify.RENAME_SOURCE
+
+
+def test_ai_title_reports_title_source(tmp_path, monkeypatch):
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    project.mkdir(parents=True)
+    (project / f"{_SESSION}.jsonl").write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "Generated"})
+    )
+
+    resolved = notify.resolve_session_name(_SESSION, cwd)
+    assert resolved is not None
+    assert resolved.source == notify.TITLE_SOURCE
+
+
+def test_history_rename_wins_over_ai_title(tmp_path, monkeypatch):
+    """A /rename recorded only in history.jsonl still beats an AI title."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    project.mkdir(parents=True)
+    (project / f"{_SESSION}.jsonl").write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "Generated"})
+    )
+    (tmp_path / ".claude" / "history.jsonl").write_text(
+        json.dumps({"sessionId": _SESSION, "display": "/rename hand-picked"})
+    )
+
+    resolved = notify.resolve_session_name(_SESSION, cwd)
+    assert resolved is not None
+    assert resolved.name == "hand-picked"
+    assert resolved.source == notify.RENAME_SOURCE
+
+
+def test_transcript_without_title_falls_back_to_index(tmp_path, monkeypatch):
+    """An early session has no title yet; the legacy index still helps if present."""
+    cwd = "/Users/x/play/lemonaid"
+    _patch_home(monkeypatch, tmp_path)
+    project = tmp_path / ".claude" / "projects" / "-Users-x-play-lemonaid"
+    _write_index(project, {"sessionId": _SESSION, "summary": "index summary"})
+    (project / f"{_SESSION}.jsonl").write_text(json.dumps({"type": "user", "cwd": cwd}))
+
+    assert notify.get_session_name(_SESSION, cwd) == "index summary"
+
+
+def test_register_working_upgrades_name_too():
+    """The submit hook path shares the same reconciliation."""
+    with tempfile.TemporaryDirectory() as tmpdir, db.connect(Path(tmpdir) / "t.db") as conn:
+        db.add(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="play-lemonaid",
+            metadata={"name_source": "environment"},
+        )
+        updated = db.register_working(
+            conn,
+            channel="claude:abc",
+            message="Working",
+            name="Fix broken notification hook",
+            metadata={"name_source": "claude_index"},
+        )
+
+        assert updated.name == "Fix broken notification hook"

--- a/tests/test_snooze.py
+++ b/tests/test_snooze.py
@@ -1,0 +1,128 @@
+"""Tests for snooze behavior in lemonaid.inbox.db."""
+
+import tempfile
+import time
+from pathlib import Path
+
+from lemonaid.inbox import db
+
+
+def _conn(tmpdir: str):
+    return db.connect(Path(tmpdir) / "test.db")
+
+
+def test_snoozed_session_leaves_active_list():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="Waiting", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        assert db.get_active(conn) == []
+        snoozed = db.get_snoozed(conn)
+        assert len(snoozed) == 1
+        assert snoozed[0].channel == "claude:abc"
+        assert snoozed[0].is_snoozed
+
+
+def test_snoozed_session_absent_from_history():
+    """A snoozed session belongs to the snoozed view, not history."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="Waiting", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        assert db.get_history(conn) == []
+
+
+def test_wake_expired_restores_previous_status():
+    """An unread session comes back unread; a read one comes back read."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        unread = db.add(conn, channel="claude:unread", message="x", switch_source="tmux")
+        read = db.add(conn, channel="claude:read", message="y", switch_source="tmux")
+        db.mark_read(conn, read.id)
+
+        past = time.time() - 1
+        db.snooze(conn, unread.id, past)
+        db.snooze(conn, read.id, past)
+
+        woken = db.wake_expired(conn)
+        assert set(woken) == {"claude:unread", "claude:read"}
+
+        statuses = {n.channel: n.status for n in db.get_active(conn)}
+        assert statuses == {"claude:unread": "unread", "claude:read": "read"}
+
+
+def test_wake_expired_leaves_future_snoozes_alone():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        assert db.wake_expired(conn) == []
+        assert len(db.get_snoozed(conn)) == 1
+
+
+def test_wake_expired_clears_snooze_columns():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() - 1)
+        db.wake_expired(conn)
+
+        woken = db.get(conn, n.id)
+        assert woken is not None
+        assert woken.snooze_until is None
+        assert woken.snooze_prev_status is None
+
+
+def test_new_attention_cancels_snooze():
+    """Fresh agent output overrides an active snooze."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        db.mark_read(conn, n.id)
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        assert db.mark_unread_for_channel(conn, "claude:abc") == 1
+
+        assert db.get_snoozed(conn) == []
+        active = db.get_active(conn)
+        assert len(active) == 1
+        assert active[0].is_unread
+        assert active[0].snooze_until is None
+
+
+def test_new_notification_cancels_snooze():
+    """An upsert from a notify hook also clears the snooze."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        db.add(conn, channel="claude:abc", message="Waiting again", switch_source="tmux")
+
+        assert db.get_snoozed(conn) == []
+        refreshed = db.get(conn, n.id)
+        assert refreshed is not None
+        assert refreshed.is_unread
+        assert refreshed.snooze_until is None
+
+
+def test_unsnooze_is_idempotent():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        db.snooze(conn, n.id, time.time() + 3600)
+
+        assert db.unsnooze(conn, "claude:abc") == 1
+        assert db.unsnooze(conn, "claude:abc") == 0
+        assert len(db.get_active(conn)) == 1
+
+
+def test_snooze_covers_whole_channel():
+    """Snooze applies to every row on the channel, like archive does."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        first = db.add(
+            conn, channel="claude:abc", message="one", switch_source="tmux", upsert=False
+        )
+        db.add(conn, channel="claude:abc", message="two", switch_source="tmux", upsert=False)
+
+        db.snooze(conn, first.id, time.time() + 3600)
+
+        rows = conn.execute(
+            "SELECT status FROM notifications WHERE channel = 'claude:abc'"
+        ).fetchall()
+        assert [r["status"] for r in rows] == ["snoozed", "snoozed"]

--- a/tests/test_snooze_screens.py
+++ b/tests/test_snooze_screens.py
@@ -1,0 +1,58 @@
+"""Tests for snooze duration parsing and wake-time formatting."""
+
+from datetime import datetime
+
+from lemonaid.inbox.tui.screens import format_wake_time, next_morning, parse_duration
+
+
+def test_parse_bare_number_is_minutes():
+    assert parse_duration("45") == 45 * 60
+
+
+def test_parse_units():
+    assert parse_duration("30m") == 30 * 60
+    assert parse_duration("2h") == 2 * 3600
+    assert parse_duration("3d") == 3 * 86400
+
+
+def test_parse_is_forgiving_about_whitespace_and_case():
+    assert parse_duration("  2H  ") == 2 * 3600
+
+
+def test_parse_accepts_fractional():
+    assert parse_duration("1.5h") == 5400
+
+
+def test_parse_rejects_nonsense():
+    for bad in ("", "   ", "soon", "m", "-5m", "0", "0h"):
+        assert parse_duration(bad) is None, bad
+
+
+def test_next_morning_same_day_when_before_nine():
+    now = datetime(2026, 7, 30, 6, 30).timestamp()
+    target = datetime.fromtimestamp(next_morning(now))
+    assert (target.month, target.day, target.hour, target.minute) == (7, 30, 9, 0)
+
+
+def test_next_morning_rolls_over_when_after_nine():
+    now = datetime(2026, 7, 30, 14, 0).timestamp()
+    target = datetime.fromtimestamp(next_morning(now))
+    assert (target.month, target.day, target.hour) == (7, 31, 9)
+
+
+def test_next_morning_is_strictly_future_at_exactly_nine():
+    now = datetime(2026, 7, 30, 9, 0).timestamp()
+    target = datetime.fromtimestamp(next_morning(now))
+    assert target.day == 31
+
+
+def test_format_wake_time_today_is_clock_only():
+    now = datetime(2026, 7, 30, 8, 0).timestamp()
+    until = datetime(2026, 7, 30, 14, 30).timestamp()
+    assert format_wake_time(until, now) == "14:30"
+
+
+def test_format_wake_time_other_day_includes_weekday():
+    now = datetime(2026, 7, 30, 8, 0).timestamp()
+    until = datetime(2026, 7, 31, 9, 0).timestamp()
+    assert format_wake_time(until, now) == "Fri 09:00"

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,0 +1,134 @@
+"""Tests for the inbox undo stack."""
+
+import tempfile
+import time
+from pathlib import Path
+
+from lemonaid.inbox import db, undo
+
+
+def _conn(tmpdir: str):
+    return db.connect(Path(tmpdir) / "test.db")
+
+
+def test_undo_archive_restores_per_row_status():
+    """Archive collapses mixed statuses; undo must restore each row's own."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        first = db.add(
+            conn, channel="claude:abc", message="one", switch_source="tmux", upsert=False
+        )
+        second = db.add(
+            conn, channel="claude:abc", message="two", switch_source="tmux", upsert=False
+        )
+        db.mark_read(conn, second.id)
+
+        entry = undo.capture(conn, "archive", "Archived x", undo.channel_row_ids(conn, first.id))
+        db.archive(conn, first.id)
+        assert db.get_active(conn) == []
+
+        undo.restore(conn, entry)
+
+        restored = {
+            r["id"]: r["status"]
+            for r in conn.execute("SELECT id, status FROM notifications").fetchall()
+        }
+        assert restored == {first.id: "unread", second.id: "read"}
+
+
+def test_undo_mark_read_restores_unread():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+
+        entry = undo.capture(conn, "mark_read", "Marked read x", [n.id])
+        db.mark_read(conn, n.id)
+        assert db.get(conn, n.id).status == "read"  # type: ignore[union-attr]
+
+        undo.restore(conn, entry)
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.is_unread
+        assert after.read_at is None
+
+
+def test_undo_snooze_returns_session_to_inbox():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+
+        entry = undo.capture(conn, "snooze", "Snoozed x", undo.channel_row_ids(conn, n.id))
+        db.snooze(conn, n.id, time.time() + 3600)
+        assert len(db.get_snoozed(conn)) == 1
+
+        undo.restore(conn, entry)
+        assert db.get_snoozed(conn) == []
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.snooze_until is None
+
+
+def test_undo_rename_restores_name_and_metadata():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", name="original")
+
+        entry = undo.capture(conn, "rename", "Renamed x", [n.id])
+        db.update_name(conn, n.id, "changed")
+        assert db.get(conn, n.id).name == "changed"  # type: ignore[union-attr]
+
+        undo.restore(conn, entry)
+        after = db.get(conn, n.id)
+        assert after is not None
+        assert after.name == "original"
+        assert "auto_name" not in after.metadata
+
+
+def test_stack_is_lifo():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        stack = undo.Stack()
+
+        stack.push(undo.capture(conn, "first", "first", [n.id]))
+        stack.push(undo.capture(conn, "second", "second", [n.id]))
+
+        assert len(stack) == 2
+        assert stack.pop().action == "second"  # type: ignore[union-attr]
+        assert stack.pop().action == "first"  # type: ignore[union-attr]
+        assert stack.pop() is None
+
+
+def test_stack_is_bounded():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        stack = undo.Stack(max_depth=3)
+
+        for i in range(5):
+            stack.push(undo.capture(conn, f"a{i}", f"a{i}", [n.id]))
+
+        assert len(stack) == 3
+        assert stack.peek().action == "a4"  # type: ignore[union-attr]
+
+
+def test_stack_ignores_empty_entries():
+    """Capturing a nonexistent row yields nothing to undo."""
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        stack = undo.Stack()
+        stack.push(undo.capture(conn, "archive", "gone", [9999]))
+
+        assert len(stack) == 0
+        assert stack.pop() is None
+
+
+def test_multi_level_undo_unwinds_in_order():
+    with tempfile.TemporaryDirectory() as tmpdir, _conn(tmpdir) as conn:
+        n = db.add(conn, channel="claude:abc", message="x", switch_source="tmux")
+        stack = undo.Stack()
+
+        stack.push(undo.capture(conn, "mark_read", "read", [n.id]))
+        db.mark_read(conn, n.id)
+
+        stack.push(undo.capture(conn, "archive", "archived", undo.channel_row_ids(conn, n.id)))
+        db.archive(conn, n.id)
+
+        undo.restore(conn, stack.pop())  # type: ignore[arg-type]
+        assert db.get(conn, n.id).status == "read"  # type: ignore[union-attr]
+
+        undo.restore(conn, stack.pop())  # type: ignore[arg-type]
+        assert db.get(conn, n.id).status == "unread"  # type: ignore[union-attr]


### PR DESCRIPTION
🍋:

Three inbox problems, plus two UI fixes that fell out of the first one.

**Session names weren't picking up Claude's generated titles.** The cause wasn't what the previous attempt (0.12.2) assumed. Claude records the generated conversation name as `type: "ai-title"` entries in the session *transcript*, and a `/rename` as `customTitle`. Lemonaid was reading `sessions-index.json`, which current Claude versions no longer maintain - 16 of 73 local project dirs had one, none written in about six months. The `session_name` hook-payload fallback added in 0.12.2 was also dead code; that field never appears in Claude's hook JSON (zero occurrences across the entire local log). Compounding both, the stored name was pinned at first sight and never revisited, so even a name that did resolve later never landed. Result: sessions showed tmux worktree names like `play-lemonaid` and `main`. After the fix, 13 of 15 live sessions show real titles.

**Snooze** gives a session that needs attention "but not yet" somewhere to go besides archive.

**Archive now says what it archived**, and is reversible - the original report was archiving something by accident and having no way to find out what it was.

## Naming precedence

A lemonaid override (`r`) always wins. Below it: Claude `/rename` > Claude's generated title > tmux/cwd placeholder.

`/rename` beats the generated title *whenever it happened*, including on a session Claude had already auto-titled, so the two are tracked as distinct sources rather than one masking the other. Placeholders are upgraded in place once a real title exists - both when a hook fires and via a periodic background re-check, since titles appear well after a session starts. Clearing an override restores the newest Claude title rather than the original placeholder.

## Snooze

`s` picks a duration: 15 minutes, 1 hour, 4 hours, tomorrow at 9am, or custom (`45m`, `2h`, `3d`; a bare number is minutes).

On expiry the session returns with the status it had when snoozed - one that was demanding attention comes back unread, one merely idle comes back read, so snoozing a quiet session doesn't manufacture a notification. New agent output cancels the snooze early: a snooze defers a state, and fresh output is a new one.

Nothing is hidden permanently. `S` lists every snoozed session with its wake time; `lemonaid inbox snoozed` shows the same list from the shell.

## Undo

`z` reverses archive, mark-read, snooze, and rename, walking back through earlier changes rather than only the last one.

The rule for what's undoable: anything that only changes a session's state in the inbox. Switching to a session and resuming one are not - they act on the terminal, which restoring a database row wouldn't take back.

Entries snapshot the affected rows *before* mutating, per-row, because `archive()` and `snooze()` act on every row of a channel and those rows need not share a status - restoring "it was probably unread" would be wrong. History is per-TUI-session and deliberately not persisted, since a snapshot stops meaning anything once another process has written to the same rows.

## Two UI fixes

Both surfaced while testing the above and touch the same refresh path.

- **Scroll flash on refresh.** The inbox rebuilt every row on each one-second tick, resetting cursor and scroll before restoring them a moment later - which presented as the list flashing to the top. Rows now update in place when the row set and its order are unchanged (the common case, where only a message or status moved). A genuine row-set change still rebuilds and keeps the cursor on its own row by key. Verified stable across five consecutive ticks while scrolled.
- **Name column sized for real titles.** Sentence-shaped names made the fixed 14-char Name column useless. Widths are now responsive: Name takes the largest share of flex space, and narrower terminals drop the columns earning it least (TTY, then Branch and Message, which CWD largely duplicates) rather than starving Name. At 80 columns Name went from 14 to 39 characters, and rows fill the terminal width exactly instead of overflowing horizontally.

## Schema

Migration `m004` adds `snooze_until` and `snooze_prev_status`. Applied against the live database at version 4.

## Testing

188 passing (up from 129). New coverage for snooze state transitions, undo snapshot/restore including the mixed-status channel case, name resolution and precedence, duration parsing and wake-time formatting, responsive column layout, and in-place row sync.

Also exercised end-to-end against the real database - snooze, archive, undo, and both alternate views - with test state cleaned up afterward.

## Known limits

- At 80 columns, 7 of 13 titles still truncate; they run 44-72 characters and no single-line layout fits them at that width. Two-line rows would fix it at the cost of halving visible sessions - not done here.
- Crossing a layout threshold takes some width back from Name to pay for the column it re-introduces. Name is never below 24 characters at any width, but it isn't strictly monotonic. Deliberate; the alternative is never showing Message or TTY.

---
<details><summary><b>Diff breakdown</b> — 49% code, 2% code-comments, 6% code-docstrings, 0.1% config, 4% docs, 38% tests</summary>

| Category | Files | +Lines | -Lines | Net | Total | % of diff |
|----------|------:|-------:|-------:|----:|------:|----------:|
| code | 8 | +991 | -137 | +854 | 1128 | 49.2% |
| code-comments | 5 | +41 | -13 | +28 | 54 | 2.4% |
| code-docstrings | 7 | +143 | -6 | +137 | 149 | 6.5% |
| config | 1 | +1 | -1 | +0 | 2 | 0.1% |
| docs | 4 | +85 | -6 | +79 | 91 | 4.0% |
| tests | 7 | +869 | -2 | +867 | 871 | 38.0% |

**code** (8 files, +991/-137):
`src/lemonaid/claude/notify.py`, `src/lemonaid/config.py`, `src/lemonaid/inbox/cli.py`, `src/lemonaid/inbox/db.py`, `src/lemonaid/inbox/migrations/m004_add_snooze.py`, `src/lemonaid/inbox/tui/app.py`, `src/lemonaid/inbox/tui/screens.py`, `src/lemonaid/inbox/undo.py`

**code-comments** (5 files, +41/-13):
`src/lemonaid/claude/notify.py`, `src/lemonaid/inbox/cli.py`, `src/lemonaid/inbox/db.py`, `src/lemonaid/inbox/tui/app.py`, `src/lemonaid/inbox/tui/screens.py`

**code-docstrings** (7 files, +143/-6):
`src/lemonaid/claude/notify.py`, `src/lemonaid/inbox/cli.py`, `src/lemonaid/inbox/db.py`, `src/lemonaid/inbox/migrations/m004_add_snooze.py`, `src/lemonaid/inbox/tui/app.py`, `src/lemonaid/inbox/tui/screens.py`, `src/lemonaid/inbox/undo.py`

**config** (1 file, +1/-1):
`pyproject.toml`

**docs** (4 files, +85/-6):
`CHANGES.md`, `README.md`, `docs/claude.md`, `docs/keybindings.md`

**tests** (7 files, +869/-2):
`tests/test_claude_notify.py`, `tests/test_column_layout.py`, `tests/test_row_sync.py`, `tests/test_session_naming.py`, `tests/test_snooze.py`, `tests/test_snooze_screens.py`, `tests/test_undo.py`

</details>