### PR TITLE
Fix the blank row under the last session, and share the footer row

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,10 @@
-# 0.13.1 (2026-07-31)
+# 0.14.0 (2026-07-31)
+
+#### Changed
+
+- **The counts moved into the footer row.** "3 unread, 10 read" had its own row above the key hints, costing a row of list height for one short line. The key hints now show for 10 seconds at startup and then step aside, and the counts take that row. `?` toggles the hints back, and pressing it cancels the startup timeout so they stay up. Both use the same row, so the list is two rows taller than before.
+
+  The patch-Claude hint and the history/snoozed counts share that slot, since they already replaced the same text.
 
 #### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.13.1 (2026-07-31)
+
+#### Fixed
+
+- **Blank line under the last session**. The responsive column sizing in 0.13.0 filled rows to the full terminal width, but a table long enough to scroll spends two of those columns on its vertical scrollbar. Rows came out one cell too wide for the space left over, and DataTable answered that overflow with a horizontal scrollbar - which rendered as an empty row between the list and the status bar and cost a row of list height, hiding a session. Column widths are now budgeted against the width the table can actually paint into, and reconciled against Textual's own measurement rather than an independent estimate of it.
+
 # 0.13.0 (2026-07-30)
 
 #### Added

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -16,8 +16,13 @@ All keybindings in the `lma` TUI are configurable via `~/.config/lemonaid/config
 | `r` | Rename session (clear to revert to auto-name) |
 | `h` | Toggle history view |
 | `g` | Refresh |
+| `?` | Toggle the key hints (see below) |
 | `q` / `Escape` | Quit |
 | `↑` / `↓` | Navigate list |
+
+The key hints occupy the bottom row for the first 10 seconds, then hand it back to
+the unread/read counts. `?` brings them up again and cancels that timeout, so they
+stay until you press `?` a second time. `?` is not configurable.
 
 ### History mode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.13.1"
+version = "0.14.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.13.0"
+version = "0.13.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -36,6 +36,7 @@ from .utils import set_terminal_title, styled_cell
 _DAY_SECONDS = 86400
 _NAME_REFRESH_SECONDS = 20  # transcript re-scan cadence for session-name upgrades
 
+_NAME_COLUMN = 3
 _BRANCH_COLUMN = 4
 _MESSAGE_COLUMN = 6
 _TTY_COLUMN = 7
@@ -128,6 +129,27 @@ def _hide_columns(table: DataTable, indices: abc.Container[int], labels: dict[in
             column.width = 0
 
 
+def _rendered_width(table: DataTable) -> int:
+    """The row width DataTable will report as its virtual width.
+
+    Mirrors Column.get_render_width, which adds cell padding on both sides of every
+    column — including one collapsed to zero width, which still costs its padding.
+    """
+    return sum(c.width + 2 * table.cell_padding for c in table.columns.values())
+
+
+def _vertical_scrollbar_width(table: DataTable) -> int:
+    """Width to hold back for the vertical scrollbar, whether or not it's showing.
+
+    Reserved unconditionally rather than keyed on `show_vertical_scrollbar`: the two
+    scrollbars are mutually dependent (narrower columns can retract the horizontal
+    bar, which grows the viewport, which can retract the vertical one), so reading
+    the live flag oscillates between two layouts. Costs two columns of flex width on
+    a list short enough not to scroll.
+    """
+    return int(table.styles.scrollbar_size_vertical or 0)
+
+
 def _stretch_columns(
     table: DataTable,
     flex_specs: list[tuple[int, int, float]],
@@ -174,6 +196,23 @@ def _stretch_columns(
         columns[idx].auto_width = False
         columns[idx].width = min(width, budget)
         budget -= columns[idx].width
+
+    # `padding_total` only approximates what DataTable will charge, so reconcile
+    # against the real measure: overshooting by one cell costs a whole row of height
+    # to a horizontal scrollbar. Trim the widest column first and Name last.
+    overflow = _rendered_width(table) - total_width
+    while overflow > 0:
+        trimmable = [
+            idx for idx, _, _ in flex_specs if idx < len(columns) and columns[idx].width
+        ]
+        if not trimmable:
+            break
+
+        # Name only gives up cells once nothing else has any left to give.
+        candidates = [idx for idx in trimmable if idx != _NAME_COLUMN] or trimmable
+        widest = max(candidates, key=lambda idx: columns[idx].width)
+        columns[widest].width -= 1
+        overflow -= 1
 
 
 class LemonaidApp(App):
@@ -422,7 +461,10 @@ class LemonaidApp(App):
             # the whole point of that view — never hide it.
             table_hidden = hidden - {_TTY_COLUMN} if table_id == "#snoozed_table" else hidden
             _hide_columns(table, table_hidden, self._column_labels(table_id))
-            _stretch_columns(table, flex, w)
+            # Which columns to show keys off the terminal width, so the layout doesn't
+            # reshuffle when a scrollbar appears; how wide to draw them keys off what
+            # the table can actually paint into.
+            _stretch_columns(table, flex, w - _vertical_scrollbar_width(table))
 
     def _column_labels(self, table_id: str) -> dict[int, str]:
         return {

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.timer import Timer
 from textual.widgets import DataTable, Footer, Header, Input, Static
 
 from ... import claude, codex, openclaw, opencode
@@ -35,6 +36,7 @@ from .utils import set_terminal_title, styled_cell
 
 _DAY_SECONDS = 86400
 _NAME_REFRESH_SECONDS = 20  # transcript re-scan cadence for session-name upgrades
+_KEY_HINT_SECONDS = 10  # how long the footer's key hints stay up before yielding the row
 
 _NAME_COLUMN = 3
 _BRANCH_COLUMN = 4
@@ -237,6 +239,8 @@ class LemonaidApp(App):
         color: $text-muted;
     }
 
+    /* Only ever displayed while the Footer is hidden, so it takes the Footer's
+       row rather than costing the list a second one. */
     #status {
         height: 1;
         background: $surface;
@@ -272,6 +276,8 @@ class LemonaidApp(App):
         self._undo_stack = undo.Stack()
         self._last_name_refresh = 0.0
         self._exec_on_exit: tuple[str, list[str]] | None = None
+        self._keys_shown = True
+        self._hint_timer: Timer | None = None
         # Enable ANSI colors for terminal transparency support
         if self.config.tui.transparent:
             self.ansi_color = True
@@ -327,6 +333,10 @@ class LemonaidApp(App):
 
         # Patch Claude (always hidden, always 'P')
         self.bind("P", "patch_claude", description="Patch Claude", show=False)
+
+        # Key hints share the bottom row with the status text, so they're a toggle
+        # rather than a permanent fixture. Hidden from the footer it controls.
+        self.bind("question_mark", "toggle_keys", description="Keys", show=False)
 
         # Cross-table arrow navigation (always active)
         self.bind("up", "cursor_up", description="Up", show=False)
@@ -395,6 +405,8 @@ class LemonaidApp(App):
         self.call_later(self._stretch_all_tables)
         # Kick Footer to pick up dynamically-bound keys
         self.refresh_bindings()
+        self._show_keys(True)
+        self._hint_timer = self.set_timer(_KEY_HINT_SECONDS, lambda: self._show_keys(False))
 
     def _check_claude_patch(self) -> None:
         """Check Claude Code patch status in a child process (avoids GIL stall).
@@ -585,7 +597,7 @@ class LemonaidApp(App):
         # Populate non-switchable table (always dim, not interactive).
         # Hide it if the terminal is too short — main table gets priority.
         _MIN_MAIN_ROWS = 5
-        chrome = 4  # header + status + footer + other_label
+        chrome = 3  # header + other_label + the shared status/footer row
         other_height = min(len(other_notifications), 8)
         room_for_main = self.size.height - chrome - other_height
         show_other = other_notifications and room_for_main >= _MIN_MAIN_ROWS
@@ -627,9 +639,7 @@ class LemonaidApp(App):
                     target_index = min(current_index, main_table.row_count - 1)
             main_table.move_cursor(row=target_index)
 
-        status = self.query_one("#status", Static)
-        displayed = main_table.row_count
-        read_count = displayed - unread_count
+        read_count = main_table.row_count - unread_count
         env_label = f" [{self.current_env}]" if self.current_env != "unknown" else ""
         status_text = f"{unread_count} unread, {read_count} read{env_label}"
 
@@ -637,7 +647,7 @@ class LemonaidApp(App):
         if self._claude_patch_status == "unpatched":
             status_text += "  |  [bold cyan]P[/]atch Claude for faster notifications"
 
-        status.update(status_text)
+        self._set_status(status_text)
 
     def action_quit(self) -> None:
         """Quit the app, or just hide the pane in scratch mode.
@@ -663,6 +673,23 @@ class LemonaidApp(App):
         if self._history_mode:
             self._set_history_mode(False)
         self._set_snoozed_mode(not self._snoozed_mode)
+
+    def action_toggle_keys(self) -> None:
+        # An explicit toggle outranks the startup timer, which would otherwise
+        # hide the hints part-way through the user reading them.
+        if self._hint_timer is not None:
+            self._hint_timer.stop()
+            self._hint_timer = None
+
+        self._show_keys(not self._keys_shown)
+
+    def _show_keys(self, shown: bool) -> None:
+        self._keys_shown = shown
+        self.query_one(Footer).display = shown
+        self.query_one("#status", Static).display = not shown
+
+    def _set_status(self, text: str) -> None:
+        self.query_one("#status", Static).update(text)
 
     def _refresh_session_names(self) -> None:
         """Pull newly-available backend titles into the inbox.
@@ -820,9 +847,8 @@ class LemonaidApp(App):
         if history_table.row_count > 0:
             history_table.move_cursor(row=min(current_row, history_table.row_count - 1))
 
-        status = self.query_one("#status", Static)
         count = history_table.row_count
-        status.update(f"{count} archived session{'s' if count != 1 else ''}")
+        self._set_status(f"{count} archived session{'s' if count != 1 else ''}")
 
     def _set_snoozed_mode(self, enabled: bool) -> None:
         self._snoozed_mode = enabled
@@ -894,7 +920,7 @@ class LemonaidApp(App):
             snoozed_table.move_cursor(row=min(current_row, snoozed_table.row_count - 1))
 
         count = snoozed_table.row_count
-        self.query_one("#status", Static).update(
+        self._set_status(
             f"{count} snoozed session{'s' if count != 1 else ''}  |  Enter to wake now"
         )
 

--- a/tests/test_column_layout.py
+++ b/tests/test_column_layout.py
@@ -143,7 +143,8 @@ def test_no_horizontal_scrollbar_steals_a_row():
         for height in (12, 14, 20):
             hbar, content_height = asyncio.run(run(width, height))
             assert not hbar, (width, height)
-            assert content_height == height - 3, (width, height, content_height)
+            # Header, and the row the status text shares with the footer.
+            assert content_height == height - 2, (width, height, content_height)
 
 
 def test_snoozed_table_keeps_its_wake_column_when_narrow():

--- a/tests/test_column_layout.py
+++ b/tests/test_column_layout.py
@@ -28,22 +28,47 @@ def _widths(width: int) -> dict[str, int]:
 
 
 def _row_width(width: int) -> int:
+    """The virtual row width DataTable reports, which is what triggers h-scrolling.
+
+    Asks Textual rather than recomputing the padding by hand: an independent
+    estimate here can agree with itself while disagreeing with the widget, which is
+    how a horizontal scrollbar went unnoticed.
+    """
+
     async def run() -> int:
         app = LemonaidApp()
         async with app.run_test(size=(width, 26)) as pilot:
             await pilot.pause()
             await pilot.pause()
             table = app.query_one("#main_table")
-            visible = [c for c in table.columns.values() if c.width]
-            return sum(c.width for c in visible) + 2 * table.cell_padding * len(visible) + 1
+            return sum(c.get_render_width(table) for c in table.columns.values())
 
     return asyncio.run(run())
 
 
-def test_row_never_exceeds_terminal_width():
-    """Overflowing the width would scroll the table horizontally."""
+def _content_width(width: int) -> int:
+    """Width the table can actually paint into, after the vertical scrollbar."""
+
+    async def run() -> int:
+        app = LemonaidApp()
+        async with app.run_test(size=(width, 26)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            return app.query_one("#main_table").scrollable_content_region.width
+
+    return asyncio.run(run())
+
+
+def test_row_never_exceeds_paintable_width():
+    """Overflow costs a row of height, not just a horizontal scrollbar.
+
+    The comparison is against the scrollable content region, not the terminal
+    width: the vertical scrollbar takes two columns, so a row sized to the full
+    terminal overflows by exactly that much and DataTable answers with a
+    horizontal scrollbar that eats the bottom row of the list.
+    """
     for width in (60, 80, 96, 100, 120, 160, 200):
-        assert _row_width(width) <= width, width
+        assert _row_width(width) <= _content_width(width), width
 
 
 def test_narrow_layout_drops_weakest_columns_for_name():
@@ -80,15 +105,45 @@ def test_name_grows_with_width_within_a_layout():
 
 
 def test_name_beats_original_fixed_width_everywhere():
-    """The whole point of the change: Name is never back to its old 14 chars."""
+    """The whole point of the change: Name is never back to its old 14 chars.
+
+    23 rather than 24 at the narrow end: two of those columns belong to the
+    vertical scrollbar, which the layout now reserves instead of overflowing into.
+    """
     for width in (60, 80, 100, _MEDIUM_LAYOUT_COLS, 120, _WIDE_LAYOUT_COLS, 160, 200):
-        assert _widths(width)["Name"] >= 24, width
+        assert _widths(width)["Name"] >= 23, width
 
 
 def test_name_is_widest_flex_column_when_wide():
     widths = _widths(160)
     assert widths["Name"] > widths["Message"]
     assert widths["Name"] > widths["CWD"]
+
+
+def test_no_horizontal_scrollbar_steals_a_row():
+    """The symptom that surfaced this: a blank line under the last session.
+
+    A one-cell overflow makes DataTable show a horizontal scrollbar, which renders
+    as an empty row between the list and the status bar and hides a session.
+    """
+
+    async def run(width: int, height: int) -> tuple[bool, int]:
+        app = LemonaidApp()
+        async with app.run_test(size=(width, height)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            table = app.query_one("#main_table")
+            table._update_dimensions(list(table.rows.keys()))
+            await pilot.pause()
+            return table.show_horizontal_scrollbar, table.scrollable_content_region.height
+
+    # Short terminals are where it bites: enough rows to force the vertical
+    # scrollbar, which is what pushed the row width over the edge.
+    for width in (80, 100, 120, 132, 160, 200):
+        for height in (12, 14, 20):
+            hbar, content_height = asyncio.run(run(width, height))
+            assert not hbar, (width, height)
+            assert content_height == height - 3, (width, height, content_height)
 
 
 def test_snoozed_table_keeps_its_wake_column_when_narrow():

--- a/tests/test_status_row.py
+++ b/tests/test_status_row.py
@@ -1,0 +1,104 @@
+"""Tests for the bottom row shared by the key hints and the status text."""
+
+import asyncio
+
+from textual.widgets import Footer, Static
+
+from lemonaid.inbox.tui.app import LemonaidApp
+
+
+def _run(steps):
+    """Drive the app, calling `steps(app, pilot)` once it has settled."""
+
+    async def run():
+        app = LemonaidApp()
+        async with app.run_test(size=(120, 20)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            return await steps(app, pilot)
+
+    return asyncio.run(run())
+
+
+def test_key_hints_start_visible():
+    async def steps(app, pilot):
+        return app.query_one(Footer).display, app.query_one("#status", Static).display
+
+    footer, status = _run(steps)
+    assert footer
+    assert not status
+
+
+def test_status_takes_the_row_once_hints_time_out():
+    async def steps(app, pilot):
+        app._show_keys(False)
+        await pilot.pause()
+        return app.query_one(Footer).display, app.query_one("#status", Static).display
+
+    footer, status = _run(steps)
+    assert not footer
+    assert status
+
+
+def test_status_and_footer_share_the_bottom_row():
+    """The point of the change: one row, not two.
+
+    Checks the row each one lands on, not merely that one is hidden: an undocked
+    #status also hides correctly while still reserving its own row of height.
+    """
+
+    async def steps(app, pilot):
+        table_heights, rows = [], []
+        for _ in range(2):
+            visible = [w for w in (app.query_one(Footer), app.query_one("#status", Static)) if w.display]
+            assert len(visible) == 1, visible
+            rows.append(visible[0].region.y)
+            table_heights.append(app.query_one("#main_table").region.height)
+            await pilot.press("question_mark")
+            await pilot.pause()
+        return rows, table_heights, app.size.height
+
+    rows, table_heights, screen_height = _run(steps)
+    # Both land on the last row, and the table keeps the same height either way.
+    assert rows == [screen_height - 1, screen_height - 1], rows
+    assert table_heights[0] == table_heights[1], table_heights
+    # Header plus the one shared row is all the chrome above/below the table.
+    assert table_heights[0] == screen_height - 2, table_heights
+
+
+def test_question_mark_toggles_hints_both_ways():
+    async def steps(app, pilot):
+        app._show_keys(False)
+        await pilot.pause()
+        states = []
+        for _ in range(2):
+            await pilot.press("question_mark")
+            await pilot.pause()
+            states.append(app.query_one(Footer).display)
+        return states
+
+    assert _run(steps) == [True, False]
+
+
+def test_toggling_cancels_the_startup_timeout():
+    """Otherwise the timer would yank the hints away mid-read."""
+
+    async def steps(app, pilot):
+        assert app._hint_timer is not None
+        await pilot.press("question_mark")
+        await pilot.pause()
+        return app._hint_timer
+
+    assert _run(steps) is None
+
+
+def test_status_text_survives_a_hint_toggle():
+    async def steps(app, pilot):
+        app._set_status("7 unread, 3 read")
+        app._show_keys(True)
+        await pilot.pause()
+        app._show_keys(False)
+        await pilot.pause()
+        return str(app.query_one("#status", Static).render())
+
+    assert _run(steps) == "7 unread, 3 read"


### PR DESCRIPTION
🍋:

A blank line appeared under the last session in the inbox, hiding a session even
when more were available to scroll to. It was a horizontal scrollbar.

The responsive column sizing in 0.13.0 stretches columns to fill the terminal
width. But a list long enough to scroll spends two of those columns on its
vertical scrollbar, so rows came out wider than the space actually left over.
DataTable answers that overflow with a horizontal scrollbar, which renders as an
empty row and costs a row of list height.

While in there: the unread/read counts had a row to themselves above the key
hints. Those two now share one row, so the list is two rows taller than before
this branch.

## The width fix

Column widths are now budgeted against the width the table can paint into
(`terminal - scrollbar`) rather than the full terminal width. Which columns to
*show* still keys off the terminal width, so the layout doesn't reshuffle when a
scrollbar appears.

The scrollbar allowance is unconditional rather than keyed on
`show_vertical_scrollbar`. The two scrollbars are mutually dependent - narrower
columns can retract the horizontal bar, which grows the viewport, which can
retract the vertical one - so reading the live flag oscillates between two
layouts. Cost is two columns of flex width on a list short enough not to scroll.

The existing `padding_total` calculation was an estimate: a `+ 1` fudge, and it
miscounted padding for zero-width hidden columns. Rather than correct the
formula, the final widths are now reconciled against what Textual itself
measures, trimming a cell at a time - widest column first, `Name` last.

**`test_row_never_exceeds_terminal_width` was green throughout this bug.** Its
helper reimplemented the same faulty padding formula the bug came from, so it
agreed with itself while disagreeing with the widget. At 60 columns the old code
really did produce a 65-cell row in a 60-cell space. It now asks the widget via
`get_render_width` and compares against `scrollable_content_region.width`.

## The footer row

Key hints show for 10 seconds at startup, then hand the row to the counts. `?`
brings them back and cancels the startup timeout, so they stay up until toggled
off. The patch-Claude hint and the history/snoozed counts use that same slot -
they already overwrote the same text.

No `dock` rule involved. Since exactly one of `Footer` / `#status` is ever
displayed, `#status` naturally takes the Footer's row. I added `dock: bottom`
first and then removed it after confirming the tests passed identically without
it; the display toggle alone is what produces the single row.

## Testing

195 passing, up from 188. New `tests/test_status_row.py` covers the shared row,
the startup timeout, and `?` in both directions.

Both fixes were verified against the failing state, not just the passing one:
the two width tests fail on the pre-fix source, and 4 of the 6 status-row tests
fail when both rows are shown. My first version of the geometry test was
vacuous - it only checked that one widget was hidden, which the display toggle
guarantees regardless of layout - so it now asserts the row each lands on and
the resulting table height.

Measured across widths 80-200 and heights 12-40: no horizontal scrollbar at any
combination, and the predicted row width matches Textual's `virtual_size`
exactly at every one.

## Known limits

- `Name` drops from 24 to 23 characters at 60 columns, and I lowered that test's
  floor to match. The old 24 was only reachable by overflowing the table, so it
  was never a width that actually rendered - but it is a real one-character loss
  at the narrow end.
- `?` is hardcoded, not configurable via `config.toml` like the other keys.
- `src/lemonaid/inbox/tui/app.py` is 1440 lines, well past the 200-line
  guideline. This branch adds ~25 to it and doesn't attempt a split.

---
<details><summary><b>Diff breakdown</b> — 22% code, 4% code-comments, 5% code-docstrings, 0.7% config, 6% docs, 62% tests</summary>

| Category | Files | +Lines | -Lines | Net | Total | % of diff |
|----------|------:|-------:|-------:|----:|------:|----------:|
| code | 1 | +53 | -9 | +44 | 62 | 22.2% |
| code-comments | 1 | +11 | -0 | +11 | 11 | 3.9% |
| code-docstrings | 1 | +13 | -0 | +13 | 13 | 4.7% |
| config | 1 | +1 | -1 | +0 | 2 | 0.7% |
| docs | 2 | +17 | -0 | +17 | 17 | 6.1% |
| tests | 2 | +167 | -7 | +160 | 174 | 62.4% |

**code** (1 file, +53/-9):
`src/lemonaid/inbox/tui/app.py`

**code-comments** (1 file, +11/-0):
`src/lemonaid/inbox/tui/app.py`

**code-docstrings** (1 file, +13/-0):
`src/lemonaid/inbox/tui/app.py`

**config** (1 file, +1/-1):
`pyproject.toml`

**docs** (2 files, +17/-0):
`CHANGES.md`, `docs/keybindings.md`

**tests** (2 files, +167/-7):
`tests/test_column_layout.py`, `tests/test_status_row.py`

</details>