### PR TITLE
codex: describe the entries Codex actually emits, so inbox rows keep moving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# 0.14.1 (2026-08-07)
+
+#### Fixed
+
+- **Codex rows stopped updating mid-turn.** The inbox writes a session's message only when the newest *describable* transcript entry has a new timestamp, and Codex's most common entries weren't described at all: it runs nearly everything through an `exec` tool that arrives as `response_item/custom_tool_call`, and puts turn boundaries in `event_msg` entries. Neither was handled, so a session could work for the better part of an hour while the row showed the last thing said before you replied. On one real session the newest described entry was 46 minutes stale, and coverage was 184 entries out of 1584.
+
+  `custom_tool_call` now reports the command (parsed out of the `tools.exec_command({"cmd":...})` wrapper it's embedded in) or the file for a patch, and `event_msg` contributes `task_started`, `agent_message`, `patch_apply_end`, and `mcp_tool_call_end`. `task_started` matters most: it's the first entry after you send a message, so it's what moves the row off the previous turn. Same session, same file: 577 described, newest entry current.
+
+  `should_dismiss` gained the same two entry kinds, so a notification clears when Codex resumes work rather than waiting for the next `reasoning` entry.
+
 # 0.14.0 (2026-07-31)
 
 #### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.14.0"
+version = "0.14.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/codex/watcher.py
+++ b/src/lemonaid/codex/watcher.py
@@ -4,15 +4,32 @@ Provides Codex-specific functions for the unified watcher:
 - get_session_path: Find session files
 - describe_activity: Describe what Codex is doing
 - should_dismiss: Detect when to auto-dismiss notifications
+
+Codex spreads one action over several entries, and the ones carrying the
+description are not the ones another backend would expect. `exec` - the tool it
+runs nearly everything through - arrives as `response_item/custom_tool_call`,
+while turn boundaries and prose arrive as `event_msg`. Anything left
+undescribed here stalls the inbox row rather than merely going unlabelled: the
+watcher only writes when the newest *describable* entry's timestamp changes, so
+a gap in coverage reads as a session that stopped working.
 """
 
 import json
+import re
 from pathlib import Path
 
 from .utils import get_sessions_root
 
 # Channel prefix for Codex notifications
 CHANNEL_PREFIX = "codex:"
+
+# Codex wraps shell work in a JS call - `tools.exec_command({"cmd":"..."})` -
+# so the command has to come back out of that argument rather than off a field.
+_EXEC_COMMAND = re.compile(r'"cmd"\s*:\s*("(?:[^"\\]|\\.)*")')
+
+# File edits arrive through the same `exec` tool, as a patch script rather than a
+# command. The header names the file, which beats reporting them all as "Running".
+_PATCH_FILE = re.compile(r"\*\*\* (?:Add|Update|Delete) File: (.+?)(?:\\n|$)")
 
 
 def get_session_path(session_id: str, cwd: str) -> Path | None:
@@ -46,15 +63,80 @@ def get_session_path(session_id: str, cwd: str) -> Path | None:
     return None
 
 
+def _describe_custom_tool_call(payload: dict) -> str:
+    """Describe a custom_tool_call, which is how Codex runs shell commands."""
+    name = payload.get("name", "")
+    if name != "exec":
+        return f"Using {name}" if name else "Working"
+
+    source = payload.get("input", "") or ""
+
+    if patch := _PATCH_FILE.search(source):
+        return f"Editing {Path(patch.group(1)).name}"
+
+    match = _EXEC_COMMAND.search(source)
+    if match is None:
+        return "Running command"
+
+    try:
+        return _describe_command(json.loads(match.group(1)))
+    except json.JSONDecodeError:
+        return "Running command"
+
+
+def _describe_event(payload: dict) -> str | None:
+    """Describe an event_msg payload.
+
+    These carry the turn boundaries. `task_started` matters most: it is the first
+    entry after you send a message, so without it the row keeps showing the last
+    thing said before your reply while Codex is already working on it.
+    """
+    event_type = payload.get("type")
+
+    if event_type == "task_started":
+        return "Working..."
+
+    if event_type == "agent_message":
+        return _first_line(payload.get("message", ""))
+
+    if event_type == "patch_apply_end":
+        return "Applied changes" if payload.get("success") else "Patch failed"
+
+    if event_type == "mcp_tool_call_end":
+        invocation = payload.get("invocation")
+        if isinstance(invocation, dict) and invocation.get("tool"):
+            return f"Using {invocation['tool']}"
+
+        return "Using a connector"
+
+    return None
+
+
+def _first_line(text: str) -> str | None:
+    """The first line of *text*, truncated, or None if there is nothing to show."""
+    if not text.strip():
+        return None
+
+    line = text.strip().split("\n")[0]
+
+    return line[:200] + "..." if len(line) > 200 else line
+
+
 def describe_activity(entry: dict) -> str | None:
     """Extract a human-readable description of what Codex is doing.
 
     Codex session entries have different formats:
     - local_shell_call: Shell command execution
     - message: User/assistant messages
-    - response_item with function_call: Tool calls
+    - response_item with function_call or custom_tool_call: Tool calls
+    - event_msg: Turn boundaries and assistant prose
     """
     entry_type = entry.get("type")
+
+    if entry_type == "event_msg":
+        payload = entry.get("payload", {})
+
+        return _describe_event(payload) if isinstance(payload, dict) else None
 
     # Shell commands - most common activity
     if entry_type == "local_shell_call":
@@ -83,6 +165,9 @@ def describe_activity(entry: dict) -> str | None:
 
         if payload_type == "function_call":
             return _describe_function_call(payload)
+
+        if payload_type == "custom_tool_call":
+            return _describe_custom_tool_call(payload)
 
         if payload_type == "web_search_call":
             action = payload.get("action", {})
@@ -121,10 +206,20 @@ def should_dismiss(entry: dict) -> bool:
         if role in ("assistant", "user"):
             return True
 
+    if entry_type == "event_msg":
+        payload = entry.get("payload", {})
+        if isinstance(payload, dict) and payload.get("type") == "task_started":
+            return True
+
     if entry_type == "response_item":
         payload = entry.get("payload", {})
         payload_type = payload.get("type")
-        if payload_type in ("function_call", "web_search_call", "reasoning"):
+        if payload_type in (
+            "function_call",
+            "custom_tool_call",
+            "web_search_call",
+            "reasoning",
+        ):
             return True
         if payload_type == "message":
             role = payload.get("role")

--- a/tests/test_codex_watcher.py
+++ b/tests/test_codex_watcher.py
@@ -14,7 +14,7 @@ def test_describe_activity_response_item_function_call_shell_command():
         "payload": {
             "type": "function_call",
             "name": "shell_command",
-            "arguments": "{\"command\":\"rg -n test\"}",
+            "arguments": '{"command":"rg -n test"}',
         },
     }
     assert watcher.describe_activity(entry) == "Running: rg -n test"
@@ -31,3 +31,103 @@ def test_describe_activity_response_item_web_search_call():
 def test_should_dismiss_for_response_item_message():
     entry = {"type": "response_item", "payload": {"type": "message", "role": "assistant"}}
     assert watcher.should_dismiss(entry) is True
+
+
+def test_describe_activity_custom_tool_call_exec():
+    """`exec` is how Codex runs nearly everything, and it carries no command field."""
+    entry = {
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": 'const r = await tools.exec_command({"cmd":"rg -n needle"});',
+        },
+    }
+    assert watcher.describe_activity(entry) == "Running: rg -n needle"
+
+
+def test_describe_activity_custom_tool_call_unescapes_the_command():
+    entry = {
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": 'tools.exec_command({"cmd":"echo \\"hi\\"\\npwd"})',
+        },
+    }
+    assert watcher.describe_activity(entry) == 'Running: echo "hi"\npwd'
+
+
+def test_describe_activity_custom_tool_call_patch_names_the_file():
+    entry = {
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": 'const patch = "*** Begin Patch\\n*** Update File: /a/b/thing.py\\n@@\\n-x\\n+y";',
+        },
+    }
+    assert watcher.describe_activity(entry) == "Editing thing.py"
+
+
+def test_describe_activity_custom_tool_call_unparseable_still_describes():
+    """A description that carries a fresh timestamp is what unsticks the row."""
+    entry = {
+        "type": "response_item",
+        "payload": {"type": "custom_tool_call", "name": "exec", "input": "something novel"},
+    }
+    assert watcher.describe_activity(entry) == "Running command"
+
+
+def test_describe_activity_task_started():
+    """The first entry after you reply - without it the row shows the previous turn."""
+    entry = {"type": "event_msg", "payload": {"type": "task_started", "turn_id": "x"}}
+    assert watcher.describe_activity(entry) == "Working..."
+
+
+def test_describe_activity_agent_message():
+    entry = {
+        "type": "event_msg",
+        "payload": {"type": "agent_message", "message": "Found it.\nMore detail here."},
+    }
+    assert watcher.describe_activity(entry) == "Found it."
+
+
+def test_describe_activity_patch_apply_end():
+    entry = {"type": "event_msg", "payload": {"type": "patch_apply_end", "success": True}}
+    assert watcher.describe_activity(entry) == "Applied changes"
+
+
+def test_describe_activity_mcp_tool_call_end():
+    entry = {
+        "type": "event_msg",
+        "payload": {
+            "type": "mcp_tool_call_end",
+            "invocation": {"server": "codex_apps", "tool": "github.create_pull_request"},
+        },
+    }
+    assert watcher.describe_activity(entry) == "Using github.create_pull_request"
+
+
+def test_describe_activity_ignores_uninteresting_events():
+    """token_count arrives constantly and says nothing about what is happening."""
+    assert (
+        watcher.describe_activity({"type": "event_msg", "payload": {"type": "token_count"}}) is None
+    )
+
+
+def test_should_dismiss_custom_tool_call():
+    entry = {"type": "response_item", "payload": {"type": "custom_tool_call", "name": "exec"}}
+    assert watcher.should_dismiss(entry) is True
+
+
+def test_should_dismiss_task_started():
+    assert (
+        watcher.should_dismiss({"type": "event_msg", "payload": {"type": "task_started"}}) is True
+    )
+
+
+def test_should_not_dismiss_token_count():
+    assert (
+        watcher.should_dismiss({"type": "event_msg", "payload": {"type": "token_count"}}) is False
+    )


### PR DESCRIPTION
🍋:

Codex sessions stop updating their inbox row mid-turn. `tars/env-banners` sat unchanged for long
stretches today while Codex was actively working, including after I answered a prompt.

The inbox writes a row's message only when the newest *describable* transcript entry carries a new
timestamp — the cache in `watcher.py` exists so a late "Permission needed" isn't overwritten by a
re-read of the same state. That means an entry the backend can't describe isn't merely unlabelled; it
stalls the row entirely.

Codex's two most common entries weren't described. It runs nearly everything through an `exec` tool
that arrives as `response_item/custom_tool_call`, and puts turn boundaries in `event_msg` entries.
Neither was handled. Claude doesn't have this problem because it emits one `assistant` entry per tool
use, so every action is describable.

On my live `env-banners` session: 184 entries described out of 1584, and the newest describable entry
was **46 minutes stale**. The tail was the giveaway — I'd sent a message at 14:38:16 and Codex had
started a turn, but every entry from that turn was skipped, so the row still showed the assistant
message from 13:52:13.

## What changed

`custom_tool_call` now reports the command. It's embedded in a JS wrapper
(`tools.exec_command({"cmd":"..."})`) rather than sitting in a field, so it's pulled out of the
argument and JSON-unescaped. File edits come through the same tool as a patch script, so those report
the file being edited instead.

`event_msg` contributes `task_started`, `agent_message`, `patch_apply_end`, and `mcp_tool_call_end`.
`task_started` is the one that matters: it's the first entry after you send a message, so it's what
moves the row off the previous turn.

`should_dismiss` gained `custom_tool_call` and `task_started`, so a notification clears when Codex
resumes rather than waiting for the next `reasoning` entry.

## Validation

Measured against the real `env-banners` session file, before and after: **184 → 577** described, and
the newest describable entry went from 13:52:13 to current. Replaying the tail shows real commands
(`lsof -ti:8080`, `kill ... && scripts/l...`) appearing with fresh timestamps where everything was
previously skipped.

37 of the 577 still fall back to a bare "Running command" — an `exec` input in a shape the parser
doesn't recognize. Those still carry a fresh timestamp, which is what unsticks the row, so the
fallback costs a label rather than the fix.

`207 passed`, 12 new in `test_codex_watcher.py` covering each new entry kind, the JSON unescaping, the
patch case, the unparseable-but-still-described fallback, and that `token_count` stays ignored (it
arrives constantly and says nothing).

Branched off `main` rather than stacked on #31. The two don't overlap in source — #31 touches
`lemon_watchers/` for tty logging, this touches `codex/` — and there's no reason for a Codex parsing
gap that predates that branch to wait on its review. The only shared file is
`tests/test_codex_watcher.py`, where #31 has a one-line quote-style reformat.
