### PR TITLE
Don't archive every live session when tmux fails to answer

### DIFF
--- a/src/lemonaid/handlers.py
+++ b/src/lemonaid/handlers.py
@@ -12,13 +12,18 @@ from .log import get_logger
 _log = get_logger("handlers")
 
 
-def check_pane_exists_by_tty(tty: str, switch_source: str) -> bool:
-    """Check if a pane still exists given its TTY and switch source.
+def check_pane_exists_by_tty(tty: str, switch_source: str) -> bool | None:
+    """Whether a pane still exists, or None if that could not be determined.
 
-    Lower-level helper that just needs TTY. Used by watcher for auto-archive.
+    The watcher archives on False, so "tmux did not answer" has to be a third
+    answer rather than folding into "no pane". Used by watcher for auto-archive.
     """
     if switch_source == "tmux":
-        session, pane_id = tmux.navigation.get_pane_for_tty(tty)
+        try:
+            session, pane_id = tmux.navigation.get_pane_for_tty(tty)
+        except tmux.navigation.TmuxUnavailable:
+            return None
+
         return session is not None and pane_id is not None
 
     elif switch_source == "wezterm":

--- a/src/lemonaid/lemon_watchers/watcher.py
+++ b/src/lemonaid/lemon_watchers/watcher.py
@@ -189,7 +189,7 @@ def check_needs_attention(
 
 
 def _check_pane_exists(tty: str, switch_source: str | None) -> bool:
-    """Check if a pane still exists for the given TTY and switch source.
+    """Whether a pane still exists, assuming it does whenever we cannot tell.
 
     Deferred import to avoid circular dependencies.
     """
@@ -198,7 +198,10 @@ def _check_pane_exists(tty: str, switch_source: str | None) -> bool:
 
     from ..handlers import check_pane_exists_by_tty
 
-    return check_pane_exists_by_tty(tty, switch_source)
+    # A tmux that failed to answer is not a pane that is gone. Archiving on it
+    # retires every live session at once, since one failed `list-panes` looks
+    # exactly like every pane having disappeared.
+    return check_pane_exists_by_tty(tty, switch_source) is not False
 
 
 def _archive_stale_sessions(

--- a/src/lemonaid/tmux/navigation.py
+++ b/src/lemonaid/tmux/navigation.py
@@ -61,10 +61,17 @@ def get_current_location() -> tuple[str | None, str | None]:
         return None, None
 
 
+class TmuxUnavailable(Exception):
+    """tmux could not answer, which is not the same as answering "no"."""
+
+
 def get_pane_for_tty(tty: str) -> tuple[str | None, str | None]:
     """Find the tmux session and pane for a given TTY.
 
-    Returns (session_name, pane_id) or (None, None) if not found.
+    Returns (session_name, pane_id), or (None, None) when no pane has that tty.
+
+    Raises TmuxUnavailable if tmux itself failed, so a caller deciding whether a
+    session is dead can tell that apart from a pane that is genuinely gone.
     """
     try:
         # List all panes with their TTY and pane ID
@@ -90,8 +97,9 @@ def get_pane_for_tty(tty: str) -> tuple[str | None, str | None]:
                 if pane_tty == tty:
                     return session_name, pane_id
 
-    except subprocess.CalledProcessError:
-        pass
+    except subprocess.CalledProcessError as e:
+        _log.warning("could not list panes to resolve %s: %s", tty, e)
+        raise TmuxUnavailable(str(e)) from e
 
     return None, None
 

--- a/tests/test_watcher_tmux_errors.py
+++ b/tests/test_watcher_tmux_errors.py
@@ -1,0 +1,85 @@
+"""A tmux that cannot answer is not a pane that is gone.
+
+`get_pane_for_tty` used to swallow a CalledProcessError and return (None, None),
+which the auto-archiver reads as "this pane no longer exists". One failed
+`tmux list-panes` therefore looked exactly like every pane having disappeared at
+once, and retired every live session in the inbox. Only an answer is allowed to
+archive something; an error has to leave the session alone.
+"""
+
+import subprocess
+
+import pytest
+
+from lemonaid import handlers
+from lemonaid.lemon_watchers import watcher
+from lemonaid.tmux import navigation
+
+
+def _tmux_fails(monkeypatch) -> None:
+    def _run(argv, **kwargs):
+        raise subprocess.CalledProcessError(1, argv)
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+
+def _tmux_lists(monkeypatch, *rows: str) -> None:
+    def _run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout="\n".join(rows) + "\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+
+def test_a_failed_lookup_is_raised_not_reported_as_absent(monkeypatch):
+    _tmux_fails(monkeypatch)
+
+    with pytest.raises(navigation.TmuxUnavailable):
+        navigation.get_pane_for_tty("/dev/ttys001")
+
+
+def test_an_unknown_tty_is_still_absent(monkeypatch):
+    _tmux_lists(monkeypatch, "/dev/ttys002|work|%3")
+
+    assert navigation.get_pane_for_tty("/dev/ttys001") == (None, None)
+
+
+def test_pane_existence_is_unknown_when_tmux_fails(monkeypatch):
+    _tmux_fails(monkeypatch)
+
+    assert handlers.check_pane_exists_by_tty("/dev/ttys001", "tmux") is None
+
+
+def test_pane_existence_is_false_when_tmux_answers(monkeypatch):
+    _tmux_lists(monkeypatch, "/dev/ttys002|work|%3")
+
+    assert handlers.check_pane_exists_by_tty("/dev/ttys001", "tmux") is False
+
+
+def test_the_watcher_keeps_a_session_whose_pane_it_cannot_check(monkeypatch):
+    """The case that archived a whole inbox: assume alive, not gone."""
+    _tmux_fails(monkeypatch)
+
+    assert watcher._check_pane_exists("/dev/ttys001", "tmux")
+
+
+def test_the_watcher_still_archives_a_pane_that_is_really_gone(monkeypatch):
+    _tmux_lists(monkeypatch, "/dev/ttys002|work|%3")
+
+    assert not watcher._check_pane_exists("/dev/ttys001", "tmux")
+
+
+def test_a_tmux_error_archives_nothing(monkeypatch):
+    """End to end: the archiver sees every session as still live."""
+    monkeypatch.setattr(watcher, "is_process_running_on_tty", lambda tty, name="claude": True)
+    _tmux_fails(monkeypatch)
+
+    archived: list[str] = []
+    watcher._archive_stale_sessions(
+        [
+            ("claude:a", "sid", "/work/one", 1.0, False, "/dev/ttys001", "msg", "tmux"),
+            ("claude:b", "sid", "/work/two", 2.0, False, "/dev/ttys002", "msg", "tmux"),
+        ],
+        archived.append,
+    )
+
+    assert archived == []


### PR DESCRIPTION
🍋:

One failed `tmux list-panes` archives every live session in the inbox.

`get_pane_for_tty` swallowed a `CalledProcessError` and returned `(None, None)` — the same value it returns when no pane has that tty. The auto-archiver reads that as "this pane no longer exists", so a single transient tmux failure looks exactly like every pane disappearing at once, and it retires every session in one pass. The agents are still running; their inbox rows just move to history.

I hit this while testing something unrelated: creating and destroying a dozen tmux sessions in quick succession is enough to make `list-panes` fail, and my whole inbox emptied.

## The fix

An error is raised (`TmuxUnavailable`) rather than reported as absence, and each caller decides what to do with it. `check_pane_exists_by_tty` returns `None` for "could not determine", and the watcher treats anything that isn't a definite `False` as still alive. Only an answer archives something.

`is_process_running_on_tty` — the other half of the same archiving decision — already worked this way, with the comment "On error, assume alive to avoid false archiving". The pane check was the one path that folded a failure into a negative answer.

## Testing

`test_a_tmux_error_archives_nothing` reproduces the failure end to end: two live sessions, tmux raising on every call, nothing archived. Four of the seven new tests fail without the fix.

Nothing recovers rows already archived this way. `db.upsert` un-archives on new activity, so an affected session returns on its own next time it fires a hook; anything else needs `h` and a manual resume.
