### PR TITLE
inbox: switch to a session by its number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
 #### Fixed
 
+- **Read sessions are no longer bold.** The card headline styled the unread marker's slot whether or not there was a dot in it, and that style is bold. A colour change does not clear the bold attribute - only a reset does - so the bold from an empty marker carried forward into the session name, putting every row on the terminal's bold face regardless of its state.
+
+- **The message is never bold**, on unread rows too. It is the one field that reads as prose rather than as a value to pick out, and a wrapped bold paragraph is harder to read than the plain one beside it.
+
 - **A finished turn says "Waiting in ..." rather than "Stop in ..."**. Claude's `Stop` hook carries no notification type of its own, so it fell through to a fallback that prints the hook's name - leaking an internal event name into the inbox. It means the same thing `idle_prompt` does, and now reads the same way, matching what the codex and openclaw backends already said for a completed turn.
 
 # 0.17.1 (2026-08-25)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,18 @@
+# 0.18.0 (unreleased)
+
+#### Added
+
+- **Digits 1-9 then 0 switch to that session**, numbered from the top of the list. The number is the row's position and nothing else: it renumbers when the list reorders, so it is a shortcut for the row you can see rather than a name a session keeps.
+
+  Only the first ten rows carry a digit; past that you scroll. A second digit would need a timeout to tell `1` from `12`, and that wait would be paid on every jump.
+
+  The non-switchable table stays unnumbered - those are sessions no terminal here can switch to, so a jump would name a row it cannot act on. Set `jump_by_number = false` under the keybindings config to leave digits unbound.
+
 # 0.17.1 (2026-08-25)
 
 #### Fixed
 
 - **Binary patcher** now finds the notification polling interval in recent Claude Code versions (tested 2.1.234–2.1.246). The previous approach searched for `XXX=6000` within 500 bytes of `notificationType` in the binary, but the constant is defined far from that marker in these versions. The patcher keeps that proximity search as a first attempt and falls back to the hook module's constant trio (`600000, 30000, 6000`).
-
 
 # 0.17.0 (2026-08-25)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 - **The message is never bold**, on unread rows too. It is the one field that reads as prose rather than as a value to pick out, and a wrapped bold paragraph is harder to read than the plain one beside it.
 
+- **Sessions whose transcript could not be found now get live messages.** The transcript directory was derived from the session's cwd, and Claude's own name for that directory does not always match - a session in `.../protostellar-visits/fast-visits-202609` was filed under `.../visits-202609`. The lookup missed, no message was ever written, and the row kept whatever generic text a hook last put there while the session was in fact talking. The path Claude reports in each hook payload is now recorded and used first, with a lookup by session id behind it.
+
 - **A finished turn no longer replaces a session's last real message.** The transcript watcher writes what the session actually said, and only rewrites when the transcript changes - so a message the `Stop` hook overwrote stayed overwritten until the session spoke again. Whether you saw the real message or a generic one came down to which of the two wrote last, which is why it hit some sessions and not others. `Stop` now leaves existing message text alone; a permission prompt or a question still replaces it, since those are news the transcript does not carry.
 
 - **A finished turn says "Waiting in ..." rather than "Stop in ..."**. Claude's `Stop` hook carries no notification type of its own, so it fell through to a fallback that prints the hook's name - leaking an internal event name into the inbox. It means the same thing `idle_prompt` does, and now reads the same way, matching what the codex and openclaw backends already said for a completed turn.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 - **The message is never bold**, on unread rows too. It is the one field that reads as prose rather than as a value to pick out, and a wrapped bold paragraph is harder to read than the plain one beside it.
 
+- **A finished turn no longer replaces a session's last real message.** The transcript watcher writes what the session actually said, and only rewrites when the transcript changes - so a message the `Stop` hook overwrote stayed overwritten until the session spoke again. Whether you saw the real message or a generic one came down to which of the two wrote last, which is why it hit some sessions and not others. `Stop` now leaves existing message text alone; a permission prompt or a question still replaces it, since those are news the transcript does not carry.
+
 - **A finished turn says "Waiting in ..." rather than "Stop in ..."**. Claude's `Stop` hook carries no notification type of its own, so it fell through to a fallback that prints the hook's name - leaking an internal event name into the inbox. It means the same thing `idle_prompt` does, and now reads the same way, matching what the codex and openclaw backends already said for a completed turn.
 
 # 0.17.1 (2026-08-25)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 0.18.0 (unreleased)
+# 0.18.0 (2026-08-25)
 
 #### Added
 
@@ -6,7 +6,11 @@
 
   Only the first ten rows carry a digit; past that you scroll. A second digit would need a timeout to tell `1` from `12`, and that wait would be paid on every jump.
 
-  The non-switchable table stays unnumbered - those are sessions no terminal here can switch to, so a jump would name a row it cannot act on. Set `jump_by_number = false` under the keybindings config to leave digits unbound.
+  The inbox only. In history Enter resumes rather than switches, and a resume is too costly to hang on one unconfirmed keystroke. The non-switchable table is unnumbered for the reverse reason: nothing there can be switched to at all. Set `jump_by_number = false` under the keybindings config to leave digits unbound.
+
+#### Fixed
+
+- **A finished turn says "Waiting in ..." rather than "Stop in ..."**. Claude's `Stop` hook carries no notification type of its own, so it fell through to a fallback that prints the hook's name - leaking an internal event name into the inbox. It means the same thing `idle_prompt` does, and now reads the same way, matching what the codex and openclaw backends already said for a completed turn.
 
 # 0.17.1 (2026-08-25)
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -7,6 +7,7 @@ All keybindings in the `lma` TUI are configurable via `~/.config/lemonaid/config
 | Key | Action |
 |-----|--------|
 | `Enter` | Open notification (switches to that session) |
+| `1`-`9`, `0` | Switch to that row of the list, counting from the top |
 | `u` | Jump directly to earliest unread session |
 | `m` | Mark as read |
 | `M` | Mark as unread again |
@@ -32,6 +33,7 @@ stay until you press `?` a second time. `?` is not configurable.
 | Key | Action |
 |-----|--------|
 | `Enter` | Resume selected session (replaces current terminal) |
+| `1`-`9`, `0` | Resume that row of the list, counting from the top |
 | `c` | Copy resume command to clipboard |
 | `T` | Spawn a tmux session around the selected session |
 | `/` | Filter by name, cwd, branch |
@@ -58,6 +60,22 @@ same list from the shell.
 
 New agent output cancels a snooze early. Snoozing means "not this state, not
 yet"; if the session produces something new, it wants you again.
+
+## Jump by number
+
+The first ten rows carry a number, shown before the session name. Pressing that
+digit switches to the row, exactly as selecting it would.
+
+The number is the row's position, so it renumbers whenever the list reorders —
+it is a shortcut for the row in front of you, not a name a session keeps. Past
+the tenth row there is no digit; scroll instead. Supporting more would mean
+waiting after each keypress to tell `1` from `12`, and that delay would be paid
+on every jump.
+
+The non-switchable table is not numbered. Those sessions belong to terminals
+this one cannot switch to, so a number would name a row it cannot act on.
+
+Set `jump_by_number = false` to leave the digits unbound.
 
 ## Undo
 
@@ -92,6 +110,7 @@ rename = "r"
 tmux_resume = "T"  # spawn tmux session from history
 save_size = "H"  # save scratch pane size (follow mode)
 flip_position = "f"  # move the scratch pane between top and left
+jump_by_number = true  # digits 1-9,0 switch to that row
 up_down = ""  # arrow key alternatives (see below)
 ```
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -33,7 +33,6 @@ stay until you press `?` a second time. `?` is not configurable.
 | Key | Action |
 |-----|--------|
 | `Enter` | Resume selected session (replaces current terminal) |
-| `1`-`9`, `0` | Resume that row of the list, counting from the top |
 | `c` | Copy resume command to clipboard |
 | `T` | Spawn a tmux session around the selected session |
 | `/` | Filter by name, cwd, branch |
@@ -71,6 +70,9 @@ it is a shortcut for the row in front of you, not a name a session keeps. Past
 the tenth row there is no digit; scroll instead. Supporting more would mean
 waiting after each keypress to tell `1` from `12`, and that delay would be paid
 on every jump.
+
+History is not numbered either. There Enter resumes rather than switches, and
+a resume is too costly to hang on one unconfirmed keystroke.
 
 The non-switchable table is not numbered. Those sessions belong to terminals
 this one cannot switch to, so a number would name a row it cannot act on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.17.1"
+version = "0.18.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -389,6 +389,11 @@ def handle_notification(stdin_data: str | None = None) -> None:
             name=name,
             metadata=metadata,
             switch_source=switch_source if switch_source != "unknown" else None,
+            # Stop knows the turn ended, not what was said in it. The watcher has
+            # the assistant's actual last line, and only rewrites when the
+            # transcript changes - so overwriting here loses that message until
+            # the session says something new.
+            keep_existing_message=notification_type == "Stop",
         )
 
     if existing:

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -336,6 +336,31 @@ def handle_session_start(stdin_data: str | None = None) -> None:
     )
 
 
+def _describe(notification_type: str, short_path: str) -> tuple[str, bool]:
+    """A hook's inbox message, and whether it is worth more than what is there.
+
+    The flag answers a question the message alone cannot: an end-of-turn hook
+    knows a turn finished but not what was said in it, while the watcher holds
+    the assistant's actual last line and only rewrites when the transcript
+    changes. Overwriting on Stop therefore loses that line until the session
+    speaks again. A prompt or a question is news the transcript does not carry,
+    so those do replace it.
+
+    Stop names the same state as idle_prompt and carries no notification type of
+    its own; without a case here it would report its hook's name as the message.
+    """
+    if notification_type in ("idle_prompt", "Stop"):
+        return f"Waiting in {short_path}", False
+
+    if notification_type == "permission_prompt":
+        return f"Permission needed in {short_path}", True
+
+    if notification_type == "PermissionRequest":
+        return f"Question in {short_path}", True
+
+    return f"{notification_type} in {short_path}", True
+
+
 def handle_notification(stdin_data: str | None = None) -> None:
     """
     Handle a Claude Code notification from stdin.
@@ -358,18 +383,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
         data.get("notification_type") or data.get("hook_event_name") or "idle_prompt"
     )
 
-    short_path = shorten_path(cwd)
-    # Stop means the turn ended, which is the same state idle_prompt names: the
-    # session is waiting on you. It carries no notification_type of its own, so
-    # without this it falls through and reports its hook's name as the message.
-    if notification_type in ("idle_prompt", "Stop"):
-        message = f"Waiting in {short_path}"
-    elif notification_type == "permission_prompt":
-        message = f"Permission needed in {short_path}"
-    elif notification_type == "PermissionRequest":
-        message = f"Question in {short_path}"
-    else:
-        message = f"{notification_type} in {short_path}"
+    message, tells_us_what_was_said = _describe(notification_type, shorten_path(cwd))
 
     channel, session_id, name, switch_source, metadata = _resolve_session(data, notification_type)
 
@@ -396,11 +410,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
             name=name,
             metadata=metadata,
             switch_source=switch_source if switch_source != "unknown" else None,
-            # Stop knows the turn ended, not what was said in it. The watcher has
-            # the assistant's actual last line, and only rewrites when the
-            # transcript changes - so overwriting here loses that message until
-            # the session says something new.
-            keep_existing_message=notification_type == "Stop",
+            keep_existing_message=not tells_us_what_was_said,
         )
 
     if existing:

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -225,6 +225,13 @@ def _resolve_session(data: dict, notification_type: str) -> tuple[str, str, str,
         "name_source": name_source,
     }
 
+    # Claude tells us where the transcript is. Deriving it from the cwd guesses
+    # at a directory name Claude chose, and the guess is wrong for some paths -
+    # a session whose transcript cannot be found gets no message updates at all.
+    transcript_path = data.get("transcript_path")
+    if transcript_path:
+        metadata["transcript_path"] = transcript_path
+
     branch = get_git_branch(cwd)
     if branch:
         metadata["git_branch"] = branch

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -352,7 +352,10 @@ def handle_notification(stdin_data: str | None = None) -> None:
     )
 
     short_path = shorten_path(cwd)
-    if notification_type == "idle_prompt":
+    # Stop means the turn ended, which is the same state idle_prompt names: the
+    # session is waiting on you. It carries no notification_type of its own, so
+    # without this it falls through and reports its hook's name as the message.
+    if notification_type in ("idle_prompt", "Stop"):
         message = f"Waiting in {short_path}"
     elif notification_type == "permission_prompt":
         message = f"Permission needed in {short_path}"

--- a/src/lemonaid/claude/watcher.py
+++ b/src/lemonaid/claude/watcher.py
@@ -14,24 +14,47 @@ from ..lemon_watchers import short_filename
 CHANNEL_PREFIX = "claude:"
 
 
-def get_session_path(session_id: str, cwd: str) -> Path | None:
-    """Find the transcript path, trying parent directories as fallback.
+def get_session_path(session_id: str, cwd: str, recorded: str = "") -> Path | None:
+    """Find a session's transcript.
 
-    Claude may store sessions under a parent directory (like git root) rather
-    than the exact cwd. This handles git worktrees where sessions live under
-    the main repo path.
+    `recorded` is the path Claude itself reported in a hook payload, and is
+    authoritative when present. The cwd-derived name is a guess at a directory
+    Claude chose, and it is wrong for paths whose encoding does not round-trip -
+    a session whose transcript is never found gets no message updates at all,
+    which reads as a session that has gone quiet.
+
+    Falls back to a project lookup by session id, which also covers sessions
+    Claude filed under a parent directory (the git-worktree case).
     """
-    if not cwd or not session_id:
+    if not session_id:
         return None
 
-    from .projects import find_project_path
+    if recorded:
+        path = Path(recorded)
+        if path.exists():
+            return path
 
-    project_path = find_project_path(cwd)
-    if not project_path:
-        return None
+    from .projects import find_project_path, find_session_project
 
-    transcript_path = project_path / f"{session_id}.jsonl"
-    return transcript_path if transcript_path.exists() else None
+    if cwd:
+        project_path = find_project_path(cwd)
+        if project_path:
+            transcript_path = project_path / f"{session_id}.jsonl"
+            if transcript_path.exists():
+                return transcript_path
+
+    # find_session_project answers with the session's cwd, not its transcript
+    # directory - so it feeds the same derivation, just from a cwd Claude
+    # confirmed rather than the one the inbox recorded.
+    found = find_session_project(session_id)
+    if found and found != cwd:
+        project_path = find_project_path(found)
+        if project_path:
+            transcript_path = project_path / f"{session_id}.jsonl"
+            if transcript_path.exists():
+                return transcript_path
+
+    return None
 
 
 def describe_activity(entry: dict) -> str | None:

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -86,6 +86,8 @@ class KeybindingsConfig:
     tmux_resume: str = "T"  # Spawn tmux session around a history entry
     save_size: str = "H"  # Save the scratch pane size (follow mode only)
     flip_position: str = "f"  # Move the scratch pane between top and left
+    # Digits 1-9 then 0 switch to that row of the list, counting from the top.
+    jump_by_number: bool = True
     up_down: str = ""  # 2-char string: up, down (e.g., "kj" for vim)
 
 

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -357,7 +357,7 @@ def _reconcile_name(
 # able to see. A hook can fire from a subprocess with no TMUX_PANE, and metadata
 # is replaced wholesale on update - so without this, one such observation erases
 # the location that `tmux restore` needs after a crash.
-_STICKY_METADATA = ("tmux_session", "tmux_window", "tmux_socket")
+_STICKY_METADATA = ("tmux_session", "tmux_window", "tmux_socket", "transcript_path")
 
 
 def _carry_forward(existing: Notification, metadata: dict[str, Any]) -> None:

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -413,11 +413,17 @@ def add(
     switch_source: str | None = None,
     created_at: float | None = None,
     status: str = "unread",
+    keep_existing_message: bool = False,
 ) -> Notification:
     """Add a notification or update existing one if upsert=True.
 
     If upsert=True and a notification exists for the channel (even if read or archived),
     it will be updated and set back to unread status.
+
+    `keep_existing_message` leaves a row's existing message text alone. It is for
+    callers that know a turn ended but not what was said in it: the transcript
+    watcher writes the better message, and only rewrites when the transcript
+    itself changes, so a message overwritten here does not come back.
     """
     now = created_at if created_at is not None else time.time()
     metadata = metadata or {}
@@ -428,6 +434,8 @@ def add(
         if existing:
             name = _reconcile_name(existing, name, metadata)
             _carry_forward(existing, metadata)
+            if keep_existing_message and existing.message:
+                message = existing.message
 
             conn.execute(
                 """

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -44,7 +44,14 @@ from ...tmux.session import spawn_session
 from .. import db, undo
 from .screens import RenameScreen, SnoozeScreen, format_wake_time
 from .table import ClickToActTable
-from .utils import FIELD_STYLES, UNREAD_MARKER_STYLE, set_terminal_title, styled_cell
+from .utils import (
+    FIELD_STYLES,
+    JUMP_DIGITS,
+    UNREAD_MARKER_STYLE,
+    jump_gutter,
+    set_terminal_title,
+    styled_cell,
+)
 
 _DAY_SECONDS = 86400
 _NAME_REFRESH_SECONDS = 20  # transcript re-scan cadence for session-name upgrades
@@ -540,6 +547,10 @@ class LemonaidApp(App):
         for b in _build_bindings(kb.save_size, "save_scratch_size", "Save Size", show=False):
             self.bind(b.key, b.action, description=b.description, show=b.show)
 
+        if self.config.tui.keybindings.jump_by_number:
+            for digit in JUMP_DIGITS:
+                self.bind(digit, f"jump_to_number('{digit}')", description="Jump", show=False)
+
         # Cross-table arrow navigation (always active)
         self.bind("up", "cursor_up", description="Up", show=False)
         self.bind("down", "cursor_down", description="Down", show=False)
@@ -864,8 +875,12 @@ class LemonaidApp(App):
         table = self.query_one("#main_table", DataTable)
         return table.cursor_coordinate.row
 
-    def _active_row(self, n: db.Notification) -> tuple[str, list[Text]]:
-        """Build the main-table row for a session, keyed by notification id."""
+    def _active_row(self, n: db.Notification, row_index: int) -> tuple[str, list[Text]]:
+        """Build the main-table row for a session, keyed by notification id.
+
+        `row_index` is the session's position in the list, which is what its jump
+        digit names - so a row's number changes when the list reorders.
+        """
         is_unread = n.is_unread
         return str(n.id), [
             styled_cell(_format_timestamp(n.created_at), is_unread, "time"),
@@ -873,7 +888,7 @@ class LemonaidApp(App):
             styled_cell(
                 _backend_label(n.channel, self.config.tui.backend_labels), is_unread, "backend"
             ),
-            styled_cell(n.name or "", is_unread, "name"),
+            jump_gutter(row_index) + styled_cell(n.name or "", is_unread, "name"),
             styled_cell(n.metadata.get("git_branch", ""), is_unread, "branch"),
             styled_cell(fish_path(n.metadata.get("cwd", "")), is_unread, "cwd"),
             styled_cell(n.message, is_unread, "message"),
@@ -938,7 +953,7 @@ class LemonaidApp(App):
         self.set_class(bool(unread_count), "-unread")
         rebuilt = _sync_rows(
             main_table,
-            [self._active_row(n) for n in current_notifications],
+            [self._active_row(n, i) for i, n in enumerate(current_notifications)],
             self._card_width(),
             self._card_shape(),
         )
@@ -1187,6 +1202,7 @@ class LemonaidApp(App):
         with db.connect() as conn:
             notifications = db.get_history(conn, search=self._history_filter)
 
+        row_index = 0
         for n in notifications:
             if not resume_mod.has_resume_command(self.config, n.channel):
                 continue
@@ -1204,7 +1220,7 @@ class LemonaidApp(App):
                     "backend",
                     history=True,
                 ),
-                styled_cell(n.name or "", False, "name", history=True),
+                jump_gutter(row_index) + styled_cell(n.name or "", False, "name", history=True),
                 styled_cell(branch, False, "branch", history=True),
                 styled_cell(cwd, False, "cwd", history=True),
                 styled_cell(n.message, False, "message", history=True),
@@ -1218,6 +1234,7 @@ class LemonaidApp(App):
             history_table.add_row(
                 *card, key=str(n.id), height=_row_height(card) if card_width else 1
             )
+            row_index += 1
 
         if history_table.row_count > 0:
             history_table.move_cursor(row=min(current_row, history_table.row_count - 1))
@@ -1781,6 +1798,23 @@ class LemonaidApp(App):
         table = self.query_one("#main_table", DataTable)
         table.move_cursor(row=earliest_row)
         table.action_select_cursor()
+
+    def action_jump_to_number(self, digit: str) -> None:
+        """Switch to the numbered session, as though it had been selected by hand.
+
+        The lower table is not numbered: it holds sessions no terminal here can
+        switch to, so a jump would name a row it cannot act on.
+        """
+        table = self.query_one("#history_table" if self._history_mode else "#main_table", DataTable)
+        if not table.display:
+            return
+
+        row = JUMP_DIGITS.find(digit)
+        if row < 0 or row >= table.row_count:
+            return
+
+        table.move_cursor(row=row)
+        self.action_select()
 
     def action_patch_claude(self) -> None:
         """Patch Claude Code binary for faster notifications."""

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -167,8 +167,12 @@ def _as_card(
     #
     # The dot rides on the name rather than owning a column: it is empty for most
     # rows, and a permanently-indented card wastes width a narrow pane hasn't got.
+    # Styled only when there is a dot to style. The marker style is bold, and a
+    # bold empty placeholder still emits the attribute - which the name that
+    # follows then inherits, since a colour change does not clear it.
     marker = cells[_UNREAD_CELL]
-    headline = Text(marker.plain or " ", style=UNREAD_MARKER_STYLE) + Text(" ") + cells[_NAME_CELL]
+    dot = Text("●", style=UNREAD_MARKER_STYLE) if marker.plain else Text(" ")
+    headline = dot + Text(" ") + cells[_NAME_CELL]
 
     context = Text(" · ", style=FIELD_STYLES["backend"]).join(
         part for part in (cells[_TIME_CELL], cells[_CWD_CELL], cells[_BRANCH_CELL]) if part.plain

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -1202,7 +1202,6 @@ class LemonaidApp(App):
         with db.connect() as conn:
             notifications = db.get_history(conn, search=self._history_filter)
 
-        row_index = 0
         for n in notifications:
             if not resume_mod.has_resume_command(self.config, n.channel):
                 continue
@@ -1220,7 +1219,7 @@ class LemonaidApp(App):
                     "backend",
                     history=True,
                 ),
-                jump_gutter(row_index) + styled_cell(n.name or "", False, "name", history=True),
+                styled_cell(n.name or "", False, "name", history=True),
                 styled_cell(branch, False, "branch", history=True),
                 styled_cell(cwd, False, "cwd", history=True),
                 styled_cell(n.message, False, "message", history=True),
@@ -1234,7 +1233,6 @@ class LemonaidApp(App):
             history_table.add_row(
                 *card, key=str(n.id), height=_row_height(card) if card_width else 1
             )
-            row_index += 1
 
         if history_table.row_count > 0:
             history_table.move_cursor(row=min(current_row, history_table.row_count - 1))
@@ -1802,10 +1800,15 @@ class LemonaidApp(App):
     def action_jump_to_number(self, digit: str) -> None:
         """Switch to the numbered session, as though it had been selected by hand.
 
-        The lower table is not numbered: it holds sessions no terminal here can
-        switch to, so a jump would name a row it cannot act on.
+        Inbox only. In history Enter resumes rather than switches, and a resume
+        is too costly to hang on a single unconfirmed keystroke. The lower table
+        is unnumbered for the same reason in reverse: nothing there can be
+        switched to at all.
         """
-        table = self.query_one("#history_table" if self._history_mode else "#main_table", DataTable)
+        if self._history_mode:
+            return
+
+        table = self.query_one("#main_table", DataTable)
         if not table.display:
             return
 

--- a/src/lemonaid/inbox/tui/utils.py
+++ b/src/lemonaid/inbox/tui/utils.py
@@ -26,6 +26,9 @@ FIELD_STYLES = {
 }
 UNREAD_MARKER_STYLE = "bold bright_red"
 
+# Fields that stay plain even when a row is demanding attention.
+_NEVER_BOLD = frozenset({"message"})
+
 # History is a record rather than a queue, so its timestamps are the settled
 # kind. Green is the live colour and belongs to the inbox.
 HISTORY_FIELD_STYLES = {**FIELD_STYLES, "time": "yellow"}
@@ -40,9 +43,13 @@ def styled_cell(
     time, and `dim` on a dark background costs enough contrast that the majority
     of the pane stops being readable - which is a high price for a distinction
     the bold unread rows already make on their own.
+
+    The message is never bold. It is the one field that reads as prose rather
+    than as a value to pick out, and a wrapped bold paragraph is harder to read
+    than the plain one beside it - the weight costs more than the emphasis buys.
     """
     style = (HISTORY_FIELD_STYLES if history else FIELD_STYLES).get(field, "default")
-    if is_unread:
+    if is_unread and field not in _NEVER_BOLD:
         return Text(value, style=f"bold {style}")
 
     return Text(value, style=style)

--- a/src/lemonaid/inbox/tui/utils.py
+++ b/src/lemonaid/inbox/tui/utils.py
@@ -46,3 +46,21 @@ def styled_cell(
         return Text(value, style=f"bold {style}")
 
     return Text(value, style=style)
+
+
+# Ten rows get a digit; 1-9 then 0, so the key's position on the keyboard runs
+# in the same direction as the list. Past that you scroll: a second digit would
+# need a timeout to tell "1" from "12", and the wait would be felt on every jump.
+JUMP_DIGITS = "1234567890"
+JUMP_GUTTER_STYLE = "bright_black"
+
+
+def jump_digit(row_index: int) -> str:
+    """The digit that jumps to `row_index`, or "" past the tenth row."""
+    return JUMP_DIGITS[row_index] if row_index < len(JUMP_DIGITS) else ""
+
+
+def jump_gutter(row_index: int) -> Text:
+    """The number that prefixes a session's name, padded so names stay aligned."""
+    digit = jump_digit(row_index)
+    return Text(f"{digit} " if digit else "  ", style=JUMP_GUTTER_STYLE)

--- a/tests/test_claude_notify.py
+++ b/tests/test_claude_notify.py
@@ -134,3 +134,92 @@ def test_a_permission_prompt_still_says_permission():
         )
         == "Permission needed in tmp/project"
     )
+
+
+def test_stop_leaves_a_real_message_alone(tmp_path, monkeypatch):
+    """The watcher's message is the better one, and it does not get rewritten.
+
+    It only writes when the transcript itself changes, so a message Stop
+    overwrites stays overwritten until the session says something new.
+    """
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+    from lemonaid.inbox import db as real_db
+
+    with real_db.connect() as conn:
+        real_db.add(conn, "claude:keep1", "The five unresolved are from tiny runs.", "a-session")
+
+    with (
+        patch(
+            "lemonaid.claude.notify.resolve_session_name",
+            return_value=notify.SessionName("a-session", notify.TITLE_SOURCE),
+        ),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys001"),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value="main"),
+    ):
+        notify.handle_notification(
+            stdin_data='{"session_id":"keep1","cwd":"/tmp/project","hook_event_name":"Stop"}'
+        )
+
+    with real_db.connect() as conn:
+        assert (
+            real_db.get_by_channel(conn, "claude:keep1", unread_only=False).message
+            == "The five unresolved are from tiny runs."
+        )
+
+
+def test_stop_on_a_new_session_still_gets_a_message(tmp_path, monkeypatch):
+    """Nothing to preserve, so the generic message is the only one there is."""
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+    from lemonaid.inbox import db as real_db
+
+    with (
+        patch(
+            "lemonaid.claude.notify.resolve_session_name",
+            return_value=notify.SessionName("fresh", notify.TITLE_SOURCE),
+        ),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys002"),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value="main"),
+    ):
+        notify.handle_notification(
+            stdin_data='{"session_id":"fresh1","cwd":"/tmp/project","hook_event_name":"Stop"}'
+        )
+
+    with real_db.connect() as conn:
+        assert (
+            real_db.get_by_channel(conn, "claude:fresh1", unread_only=False).message
+            == "Waiting in tmp/project"
+        )
+
+
+def test_a_permission_prompt_does_overwrite(tmp_path, monkeypatch):
+    """A question is news the transcript does not carry, so it replaces."""
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+    from lemonaid.inbox import db as real_db
+
+    with real_db.connect() as conn:
+        real_db.add(conn, "claude:perm1", "Some earlier chatter.", "a-session")
+
+    with (
+        patch(
+            "lemonaid.claude.notify.resolve_session_name",
+            return_value=notify.SessionName("a-session", notify.TITLE_SOURCE),
+        ),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys003"),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value="main"),
+    ):
+        notify.handle_notification(
+            stdin_data='{"session_id":"perm1","cwd":"/tmp/project",'
+            '"hook_event_name":"Notification","notification_type":"permission_prompt"}'
+        )
+
+    with real_db.connect() as conn:
+        assert (
+            real_db.get_by_channel(conn, "claude:perm1", unread_only=False).message
+            == "Permission needed in tmp/project"
+        )

--- a/tests/test_claude_notify.py
+++ b/tests/test_claude_notify.py
@@ -97,3 +97,40 @@ def test_submit_records_no_location_outside_tmux():
     metadata = register.call_args.kwargs["metadata"]
     assert "tmux_session" not in metadata
     assert "tmux_window" not in metadata
+
+
+def _message_for(payload: str) -> str:
+    """The inbox message a hook payload produces."""
+    with (
+        patch("lemonaid.claude.notify.db.connect", _fake_connect),
+        patch(
+            "lemonaid.claude.notify.resolve_session_name",
+            return_value=notify.SessionName("Test Session", notify.TITLE_SOURCE),
+        ),
+        patch("lemonaid.claude.notify.get_tmux_session_name", return_value=None),
+        patch("lemonaid.claude.notify.get_tty", return_value="/dev/ttys001"),
+        patch("lemonaid.claude.notify.detect_terminal_switch_source", return_value="tmux"),
+        patch("lemonaid.claude.notify.get_git_branch", return_value="main"),
+        patch("lemonaid.claude.notify.db.get_by_channel", return_value=None),
+        patch("lemonaid.claude.notify.db.add") as mock_add,
+    ):
+        notify.handle_notification(stdin_data=payload)
+
+    return mock_add.call_args.kwargs["message"]
+
+
+def test_a_finished_turn_says_it_is_waiting():
+    """Stop carries no notification_type, and used to report its hook's name."""
+    message = _message_for('{"session_id":"abc123","cwd":"/tmp/project","hook_event_name":"Stop"}')
+    assert message == "Waiting in tmp/project"
+    assert "Stop" not in message
+
+
+def test_a_permission_prompt_still_says_permission():
+    assert (
+        _message_for(
+            '{"session_id":"abc123","cwd":"/tmp/project",'
+            '"hook_event_name":"Notification","notification_type":"permission_prompt"}'
+        )
+        == "Permission needed in tmp/project"
+    )

--- a/tests/test_inbox_cards.py
+++ b/tests/test_inbox_cards.py
@@ -10,7 +10,7 @@ import asyncio
 from rich.text import Text
 
 from lemonaid.inbox.tui import app
-from lemonaid.inbox.tui.utils import styled_cell
+from lemonaid.inbox.tui.utils import FIELD_STYLES, styled_cell
 from lemonaid.tmux import scratch
 
 
@@ -133,10 +133,12 @@ def test_a_card_keeps_the_colours_its_cells_arrived_with():
     body, _ = app._as_card(cells, 60)
 
     spans = {body.plain[s.start : s.end]: s.style for s in body.spans}
-    assert spans["a-name"] == "bold cyan"
-    assert spans["15:24"] == "bold green"
-    assert spans["~/w/repo"] == "bold blue"
-    assert spans["a/branch"] == "bold magenta"
+    # Against the palette rather than a copy of it: the claim is that a card
+    # preserves the colour its cell arrived with, whatever that colour is.
+    assert spans["a-name"] == f"bold {FIELD_STYLES['name']}"
+    assert spans["15:24"] == f"bold {FIELD_STYLES['time']}"
+    assert spans["~/w/repo"] == f"bold {FIELD_STYLES['cwd']}"
+    assert spans["a/branch"] == f"bold {FIELD_STYLES['branch']}"
 
 
 def test_a_card_spends_one_column_on_its_gutter():
@@ -277,3 +279,42 @@ def test_a_scratch_pane_on_top_is_columns_whatever_its_size(monkeypatch, tmp_pat
 def test_a_plain_lma_still_decides_from_its_shape():
     assert app.LemonaidApp()._cards(58, 89)
     assert not app.LemonaidApp()._cards(245, 16)
+
+
+def test_a_read_card_emits_no_bold_at_all():
+    """Bold on the marker slot would bleed into the name beside it.
+
+    A colour change does not clear the bold attribute - only a reset does - so a
+    bold placeholder in the empty marker slot puts every following field on the
+    terminal's bold face, whatever the app thinks it asked for. The rendered
+    attributes are the thing to assert on; the source styles look right either way.
+    """
+    cells = [
+        styled_cell("15:24", False, "time"),
+        Text(""),  # read: no dot
+        styled_cell("CC", False, "backend"),
+        styled_cell("a-name", False, "name"),
+        styled_cell("", False, "branch"),
+        styled_cell("~/w/repo", False, "cwd"),
+        styled_cell("a message", False, "message"),
+    ]
+    body, _ = app._as_card(cells, 60)
+
+    assert not any("bold" in str(span.style) for span in body.spans)
+
+
+def test_an_unread_card_bolds_the_dot_but_not_the_message():
+    cells = [
+        styled_cell("15:24", True, "time"),
+        Text("●"),
+        styled_cell("CC", True, "backend"),
+        styled_cell("a-name", True, "name"),
+        styled_cell("", True, "branch"),
+        styled_cell("~/w/repo", True, "cwd"),
+        styled_cell("a message", True, "message"),
+    ]
+    body, _ = app._as_card(cells, 60)
+    styles = {body.plain[s.start : s.end]: str(s.style) for s in body.spans}
+
+    assert "bold" in styles["a-name"], "an unread name is bold"
+    assert "bold" not in styles["a message"], "the message reads as prose, never bold"

--- a/tests/test_jump_by_number.py
+++ b/tests/test_jump_by_number.py
@@ -1,0 +1,131 @@
+"""Jumping to a session by its number.
+
+The list is numbered from the top, so a row's digit is its position and nothing
+more: it changes when the list reorders, and it survives no refresh. That is the
+whole contract, and these tests pin the edges of it - the tenth row, the eleventh
+that has no digit, and the digit typed into a search box that must stay a digit.
+"""
+
+import asyncio
+import itertools
+
+from lemonaid.inbox import db
+from lemonaid.inbox.tui.app import LemonaidApp
+from lemonaid.inbox.tui.utils import jump_digit, jump_gutter
+
+_ids = itertools.count(700)
+
+
+def _active(name: str) -> int:
+    """A live session in the main table, switchable from this environment."""
+    with db.connect() as conn:
+        n = db.add(
+            conn,
+            f"claude:{name}",
+            "a message",
+            name,
+            {"tty": f"/dev/ttys{next(_ids)}", "cwd": "/tmp", "session_id": f"s{next(_ids)}"},
+        )
+        conn.execute("UPDATE notifications SET switch_source = 'tmux' WHERE id = ?", (n.id,))
+        conn.commit()
+        return n.id
+
+
+def _run(steps, size=(120, 40), monkeypatch=None):
+    if monkeypatch is not None:
+        monkeypatch.setattr(LemonaidApp, "_archive_channel", lambda self, channel: None)
+
+    async def run():
+        app = LemonaidApp()
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            return await steps(app, pilot)
+
+    return asyncio.run(run())
+
+
+def test_the_tenth_row_is_zero_and_the_eleventh_has_no_digit():
+    assert jump_digit(0) == "1"
+    assert jump_digit(8) == "9"
+    assert jump_digit(9) == "0"
+    assert jump_digit(10) == ""
+
+
+def test_an_unnumbered_row_still_pads_so_names_stay_aligned():
+    assert jump_gutter(0).plain == "1 "
+    assert len(jump_gutter(10).plain) == len(jump_gutter(0).plain)
+
+
+def test_the_digit_prefixes_the_name(monkeypatch):
+    for i in range(3):
+        _active(f"jump-name-{i}")
+
+    async def steps(app, pilot):
+        from textual.widgets import DataTable
+
+        table = app.query_one("#main_table", DataTable)
+        return [table.get_row_at(r)[3].plain for r in range(min(3, table.row_count))]
+
+    names = _run(steps, monkeypatch=monkeypatch)
+    assert names, "no rows rendered"
+    assert names[0].startswith("1 ")
+
+
+def test_a_digit_past_the_last_row_does_nothing(monkeypatch):
+    _active("jump-only-one")
+
+    async def steps(app, pilot):
+        from textual.widgets import DataTable
+
+        table = app.query_one("#main_table", DataTable)
+        before = table.cursor_coordinate.row
+        app.action_jump_to_number("0")
+        return before, table.cursor_coordinate.row
+
+    before, after = _run(steps, monkeypatch=monkeypatch)
+    assert before == after
+
+
+def test_a_digit_selects_the_row_at_that_position(monkeypatch):
+    """The jump lands on the row and then acts on it, as Enter would."""
+    for i in range(3):
+        _active(f"jump-move-{i}")
+
+    selected: list[int] = []
+
+    async def steps(app, pilot):
+        from textual.widgets import DataTable
+
+        table = app.query_one("#main_table", DataTable)
+        monkeypatch.setattr(
+            LemonaidApp,
+            "action_select",
+            lambda self: selected.append(table.cursor_coordinate.row),
+        )
+        app.action_jump_to_number("2")
+        return table.cursor_coordinate.row
+
+    row = _run(steps, monkeypatch=monkeypatch)
+    assert row == 1
+    assert selected == [1], "the row was moved to but never selected"
+
+
+def test_a_digit_typed_into_the_history_filter_stays_a_digit(monkeypatch):
+    """The filter is a text box; a digit there is search input, not a jump."""
+
+    async def steps(app, pilot):
+        from textual.widgets import Input
+
+        app._set_history_mode(True)
+        await pilot.pause()
+        app.action_filter_history()
+        await pilot.pause()
+        filter_input = app.query_one("#history_filter", Input)
+        filter_input.focus()
+        await pilot.pause()
+        await pilot.press("3")
+        await pilot.pause()
+        return filter_input.value
+
+    assert _run(steps, monkeypatch=monkeypatch) == "3"

--- a/tests/test_jump_by_number.py
+++ b/tests/test_jump_by_number.py
@@ -111,6 +111,23 @@ def test_a_digit_selects_the_row_at_that_position(monkeypatch):
     assert selected == [1], "the row was moved to but never selected"
 
 
+def test_history_is_not_numbered(monkeypatch):
+    """Enter resumes in history, which is too costly for one unconfirmed key."""
+
+    async def steps(app, pilot):
+        from textual.widgets import DataTable
+
+        app._set_history_mode(True)
+        await pilot.pause()
+        table = app.query_one("#history_table", DataTable)
+        before = table.cursor_coordinate.row
+        app.action_jump_to_number("2")
+        return before, table.cursor_coordinate.row
+
+    before, after = _run(steps, monkeypatch=monkeypatch)
+    assert before == after
+
+
 def test_a_digit_typed_into_the_history_filter_stays_a_digit(monkeypatch):
     """The filter is a text box; a digit there is search input, not a jump."""
 

--- a/tests/test_session_path_lookup.py
+++ b/tests/test_session_path_lookup.py
@@ -1,0 +1,59 @@
+"""Finding a session's transcript when the cwd does not name its directory.
+
+Claude derives its own project directory name, and the derivation does not
+round-trip for every path. A session whose transcript is never found gets no
+message updates at all, which in the inbox reads as a session that went quiet
+rather than one nobody can see.
+"""
+
+from lemonaid.claude import watcher
+
+
+def test_the_recorded_path_wins(tmp_path, monkeypatch):
+    """Claude reports the transcript in every hook payload; trust it."""
+    recorded = tmp_path / "somewhere" / "abc.jsonl"
+    recorded.parent.mkdir(parents=True)
+    recorded.write_text("{}\n")
+
+    assert watcher.get_session_path("abc", "/any/cwd", str(recorded)) == recorded
+
+
+def test_a_recorded_path_that_no_longer_exists_is_not_used(tmp_path):
+    gone = str(tmp_path / "gone.jsonl")
+
+    assert watcher.get_session_path("abc", "", gone) is None
+
+
+def test_the_cwd_derivation_still_works(tmp_path, monkeypatch):
+    project = tmp_path / "-tmp-proj"
+    project.mkdir()
+    (project / "sid1.jsonl").write_text("{}\n")
+
+    monkeypatch.setattr(
+        "lemonaid.claude.projects.find_project_path",
+        lambda cwd: project if cwd == "/tmp/proj" else None,
+    )
+
+    assert watcher.get_session_path("sid1", "/tmp/proj") == project / "sid1.jsonl"
+
+
+def test_a_session_id_lookup_rescues_a_cwd_that_does_not_derive(tmp_path, monkeypatch):
+    """The inbox's cwd and the cwd Claude filed the session under can differ."""
+    project = tmp_path / "-real-dir"
+    project.mkdir()
+    (project / "sid2.jsonl").write_text("{}\n")
+
+    monkeypatch.setattr(
+        "lemonaid.claude.projects.find_project_path",
+        lambda cwd: project if cwd == "/real/dir" else None,
+    )
+    monkeypatch.setattr(
+        "lemonaid.claude.projects.find_session_project",
+        lambda session_id: "/real/dir" if session_id == "sid2" else None,
+    )
+
+    assert watcher.get_session_path("sid2", "/what/the/inbox/recorded") == project / "sid2.jsonl"
+
+
+def test_no_session_id_is_not_a_lookup(tmp_path):
+    assert watcher.get_session_path("", "/tmp/proj") is None


### PR DESCRIPTION
🍋:

Digits `1`-`9` then `0` switch to that row of the inbox, counting from the top.

Testing that turned up four display bugs, all fixed here. The one worth reading about is the third: sessions whose transcript lemonaid could not locate never received a message update at all, so their rows sat on whatever generic text a hook last wrote while the session was actively talking. Two sessions in a live inbox were affected.

The bugs are independent of the feature and of each other. They are together because each was found while looking at the pane.

## Jump by number

The number is the row's position and nothing more — it renumbers whenever the list reorders, so it is a shortcut for the row in front of you rather than a name a session keeps. Pinning an order so numbers stay put is a separate idea, and this does not try to be it.

Ten rows get a digit. Past that you scroll — a second digit would need a timeout to tell `1` from `12`, and that wait would be paid on every jump. Rows past the tenth get blank padding in the same slot so names stay aligned rather than shifting left.

The number is rendered into the existing name cell rather than as a new column. Row cells are built positionally against index constants (`_TIME_CELL` through `_MSG_CELL`), so adding a cell would shift every one of them and each construction site. A gutter column is still possible later; this keeps the diff to the one place that builds a name.

**Inbox only.** History is not numbered: `Enter` there resumes rather than switches, and a resume is too costly to hang on one unconfirmed keystroke. The non-switchable table is unnumbered for the reverse reason — those sessions belong to terminals this one cannot switch to, so a number would name a row it cannot act on.

`jump_by_number = true` under `[tui.keybindings]`, on by default. One boolean rather than ten key fields.

## Sessions that never got a message

The transcript directory was derived from the session's cwd by path-mangling, and Claude's own name for that directory does not always match:

```
derived:  ...-work-ds-monorepo-protostellar-visits-fast-visits-202609
actual:   ...-work-ds-monorepo-visits-202609
```

The lookup missed, `get_latest_activity` returned `None`, and no message was ever written for that channel. The row kept whatever a hook last put there, which reads as a session gone quiet.

Claude reports `transcript_path` in every hook payload. It is now recorded in metadata, carried forward like the tmux location fields, and tried first. Behind it sits the existing `find_session_project` lookup by session id, which covers rows that predate this. The cwd derivation stays in the middle as the cheap path.

## A finished turn replaced the last real message

The watcher writes what the session actually said and only rewrites when the transcript changes. The `Stop` hook overwrote that with `Waiting in <path>`, and since the transcript had not moved, the watcher did not put it back. Whether you saw the real message came down to which of the two wrote last — a race, which is why it hit some sessions and not others.

`Stop` now leaves existing message text alone. A permission prompt or a question still replaces it: those are news the transcript does not carry. One `_describe` call returns both the message and whether the hook knows enough to overwrite, so the hook type is matched once rather than in two places that had to agree.

`Stop` also used to report its own hook name — `Stop in <path>` — because it sends no `notification_type` and fell through to a fallback that formats whatever name it received.

## Every row rendered bold

The card headline styled the unread marker's slot whether or not there was a dot in it, and that style is bold. A colour change does not clear the bold attribute — only a reset does — so the bold from an empty marker carried into the session name and everything after it. Read rows were indistinguishable from unread ones.

What the terminal received for a row with *no* dot:

```
ESC[1m ESC[91m   ESC[90m 6 ESC[36m mops-console/resolve-memo-pods
```

The regression test asserts on rendered attributes rather than source styles. Every source-level check said the app emitted no bold for read rows, which was true and beside the point — the leak happens between cells, where only the output shows it.

The message field is now never bold either, including on unread rows. It is the one field that reads as prose rather than as a value to pick out.

## Testing

592 passing. The four `test_follow_hook` failures are present on `main` unmodified and are not from this branch. `test_header_state` and `test_history_live_session` each failed once across several runs and pass in isolation — the watcher-thread flake, not a regression.

Each fix was checked by reverting it and confirming its test fails: the bold leak, the `Stop` overwrite, and the `Stop in` message. The transcript lookup was verified against a live inbox — two previously unresolvable sessions now resolve, and the four that remain are the ones `tmux doctor` already reports as having no transcript on disk.

Rebased on `main` at `e9449e1`. The changelog keeps both `0.18.0` and main's `0.17.1`.
