### PR TITLE
fix: binary patcher finds notification interval on Claude Code 2.1.16+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 0.17.1 (2026-08-25)
+
+#### Fixed
+
+- **Binary patcher** now finds the notification polling interval in recent Claude Code versions (tested 2.1.234–2.1.246). The previous approach searched for `XXX=6000` within 500 bytes of `notificationType` in the binary, but the constant is defined far from that marker in these versions. The patcher keeps that proximity search as a first attempt and falls back to the hook module's constant trio (`600000, 30000, 6000`).
+
+
 # 0.17.0 (2026-08-25)
 
 #### Added

--- a/docs/claude-patch.md
+++ b/docs/claude-patch.md
@@ -48,19 +48,30 @@ The TUI will show the warning again when an update invalidates the patch.
 
 ## Technical details
 
-### Version-specific patterns
+### How the pattern is found
 
-The minified variable name for the polling interval has changed across versions:
+The minified variable name for the polling interval changes across versions.
 
-| Version | Original pattern | Patched pattern |
-|---------|-----------------|-----------------|
-| < 2.1.0 | `ewD=6000` | `ewD=0500` |
-| >= 2.1.0 | `spB=6000` | `spB=0500` |
+Versions before 2.1.0 and 2.1.0–2.1.15 use hardcoded patterns (`ewD=6000` and
+`spB=6000` respectively).
 
-If a future version changes the pattern again, lemonaid will report status as "unknown" and we'll need to:
+For 2.1.16+, the patcher tries two dynamic strategies in order:
 
-1. Find the new pattern: `grep -boa 'setInterval' ~/.local/share/claude/versions/<version>` and look for notification-related intervals
-2. Update `get_pattern_for_version()` in `src/lemonaid/claude/patcher.py`
+1. **Proximity search**: looks for `XXX=6000` within 500 bytes of `notificationType`
+   in the binary.
+
+2. **Trio search**: the hook module defines three constants together in the bundled
+   source — `var XX=600000, YY=30000, ZZ=6000`. The variable names change per build
+   but the trio structure is stable across all tested versions (2.1.234–2.1.246).
+
+| Strategy | Original pattern | Patched pattern |
+|----------|-----------------|-----------------|
+| proximity | `XXX=6000` near `notificationType` | `XXX=0500` |
+| trio | `600000, 30000, ZZZ=6000` | `ZZZ= 500` |
+
+Tested on 2.1.234–2.1.246; the trio search is what succeeds on those versions.
+
+If no strategy finds the pattern, lemonaid reports status as "unknown".
 
 ### macOS code signing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.17.0"
+version = "0.17.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/patcher.py
+++ b/src/lemonaid/claude/patcher.py
@@ -22,41 +22,27 @@ def parse_version(name: str) -> tuple[int, ...] | None:
     return None
 
 
-def find_notification_polling_pattern(content: bytes, check_patched: bool = False) -> bytes | None:
-    """Find the notification polling interval pattern dynamically.
-
-    The minified variable name changes with each build, so we search for
-    patterns like 'XXX=6000' that appear near 'notificationType' in the code.
-
-    If check_patched=True, also look for already-patched 'XXX=0500' patterns.
-    """
-    # Look for short identifier = 6000 patterns (1-3 char identifiers)
-    # Also check for =0500 (patched) if requested
+def _find_near_notification_type(content: bytes, check_patched: bool = False) -> bytes | None:
+    """Search for XXX=6000 within 500 bytes of 'notificationType'."""
     if check_patched:
         pattern = rb"[a-zA-Z][a-zA-Z0-9]{0,2}=(?:6000|0500)"
     else:
         pattern = rb"[a-zA-Z][a-zA-Z0-9]{0,2}=6000"
     matches = list(re.finditer(pattern, content))
-
     if not matches:
         return None
 
     # Find the match that's closest to 'notificationType' - that's the polling interval
     notification_marker = b"notificationType"
     marker_positions = [m.start() for m in re.finditer(notification_marker, content)]
-
     if not marker_positions:
-        # Fallback: return the first match (less reliable)
-        return matches[0].group()
+        return None
 
     best_match = None
     best_distance = float("inf")
-
     for match in matches:
-        pos = match.start()
-        # Find distance to nearest notificationType marker
         for marker_pos in marker_positions:
-            distance = abs(pos - marker_pos)
+            distance = abs(match.start() - marker_pos)
             if distance < best_distance:
                 best_distance = distance
                 best_match = match.group()
@@ -65,8 +51,41 @@ def find_notification_polling_pattern(content: bytes, check_patched: bool = Fals
     # In practice, the correct pattern is ~74 bytes away, next closest is ~5000+
     if best_distance < 500:
         return best_match
-
     return None
+
+
+def _find_trio_pattern(content: bytes, check_patched: bool = False) -> bytes | None:
+    """Find the hook module's constant trio (600000, 30000, 6000)."""
+    if check_patched:
+        trio = re.search(
+            rb"=600000,([a-zA-Z][a-zA-Z0-9_$]*)=30000,"
+            rb"([a-zA-Z][a-zA-Z0-9_$]*)=(?:6000| 500)(?![0-9])",
+            content,
+        )
+    else:
+        trio = re.search(
+            rb"=600000,([a-zA-Z][a-zA-Z0-9_$]*)=30000,"
+            rb"([a-zA-Z][a-zA-Z0-9_$]*)=6000(?![0-9])",
+            content,
+        )
+    if trio is None:
+        return None
+
+    var_name = trio.group(2)
+    value_start = trio.start(2) + len(var_name) + 1  # after '='
+    value = content[value_start : value_start + 4]
+    return var_name + b"=" + value
+
+
+def find_notification_polling_pattern(content: bytes, check_patched: bool = False) -> bytes | None:
+    """Find the notification polling interval pattern dynamically.
+
+    Tries proximity to 'notificationType' first (worked on earlier builds),
+    then falls back to the hook module's constant trio (600000, 30000, 6000).
+    """
+    return _find_near_notification_type(content, check_patched) or _find_trio_pattern(
+        content, check_patched
+    )
 
 
 def get_pattern_for_version(
@@ -84,11 +103,15 @@ def get_pattern_for_version(
         return (b"spB=6000", b"spB=0500")
     # v2.1.16+: find pattern dynamically (minified names change per build)
     if content is not None:
-        original = find_notification_polling_pattern(content)
+        # Try proximity to notificationType first (bytecode context, 0500 is safe)
+        original = _find_near_notification_type(content)
         if original:
-            # Replace 6000 with 0500 in the pattern
-            patched = original.replace(b"6000", b"0500")
-            return (original, patched)
+            return (original, original.replace(b"6000", b"0500"))
+        # Fall back to the constant trio (readable source, strict mode —
+        # 0500 is an octal literal which strict mode forbids)
+        original = _find_trio_pattern(content)
+        if original:
+            return (original, original.replace(b"6000", b" 500"))
     return None
 
 
@@ -153,7 +176,7 @@ def check_status(binary_path: Path) -> str:
         found = find_notification_polling_pattern(content, check_patched=True)
         if found is None:
             return "unknown"
-        if b"=0500" in found:
+        if b"=0500" in found or b"= 500" in found:
             return "patched"
         if b"=6000" in found:
             return "unpatched"


### PR DESCRIPTION
When I set it up, I had an `unknown` patch status so I sent claude off to figure it out

**Binary patcher** now finds the notification polling interval in recent Claude Code versions (tested 2.1.234–2.1.246). The previous approach searched for `XXX=6000` within 500 bytes of `notificationType` in the binary, but the constant is defined far from that marker in these versions. The patcher keeps that proximity search as a first attempt and falls back to the hook module's constant trio (`600000, 30000, 6000`).


> how the trio was identified: jBi=6000 is exported as `x$`, imported as `Be` by the notification `setTimeout`, and has no other consumers — so patching it only affects notification polling. That chain was verified on 2.1.245, not assumed from the variable names.