### PR TITLE
Drop notifications that can't name their session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.18.1 (2026-08-25)
+
+#### Fixed
+
+- **A notification that cannot name its session is dropped rather than filed under a shared `unknown` channel.** Every backend collapsed a missing session id into one pseudo-session per backend, which then took the tty of whatever shell delivered it - so it appeared in the inbox sitting on a real pane, and the next such notification upserted over it. In practice every payload carries an id, so this only fires on a malformed call; dropping it with a logged warning is better than parking it on a pane in use.
+
 # 0.18.0 (2026-08-25)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.18.0"
+version = "0.18.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -28,7 +28,7 @@ import typing as ty
 from pathlib import Path
 
 from ..inbox import db
-from ..inbox.channel import channel_id
+from ..inbox.channel import UnidentifiedSession, channel_id
 from ..lemon_watchers import (
     detect_terminal_switch_source,
     get_git_branch,
@@ -277,7 +277,11 @@ def handle_submit(stdin_data: str | None = None) -> None:
     except json.JSONDecodeError:
         data = {}
 
-    channel, session_id, name, switch_source, metadata = _resolve_session(data, "working")
+    try:
+        channel, session_id, name, switch_source, metadata = _resolve_session(data, "working")
+    except UnidentifiedSession:
+        _log.warning("dropped a working notification with no session id")
+        return
     message = f"Working in {shorten_path(data.get('cwd', 'unknown'))}"
 
     with db.connect() as conn:
@@ -313,7 +317,11 @@ def handle_session_start(stdin_data: str | None = None) -> None:
     except json.JSONDecodeError:
         data = {}
 
-    channel, _session_id, name, switch_source, metadata = _resolve_session(data, "started")
+    try:
+        channel, _session_id, name, switch_source, metadata = _resolve_session(data, "started")
+    except UnidentifiedSession:
+        _log.warning("dropped a session-start notification with no session id")
+        return
     source = data.get("source", "startup")
     metadata["session_start_source"] = source
 
@@ -385,7 +393,13 @@ def handle_notification(stdin_data: str | None = None) -> None:
 
     message, tells_us_what_was_said = _describe(notification_type, shorten_path(cwd))
 
-    channel, session_id, name, switch_source, metadata = _resolve_session(data, notification_type)
+    try:
+        channel, session_id, name, switch_source, metadata = _resolve_session(
+            data, notification_type
+        )
+    except UnidentifiedSession:
+        _log.warning("dropped a %s notification with no session id", notification_type)
+        return
 
     # Check existing state before upsert for logging
     with db.connect() as conn:

--- a/src/lemonaid/codex/notify.py
+++ b/src/lemonaid/codex/notify.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 from ..inbox import db
-from ..inbox.channel import channel_id
+from ..inbox.channel import UnidentifiedSession, channel_id
 from ..lemon_watchers import (
     detect_terminal_switch_source,
     get_git_branch,
@@ -167,7 +167,11 @@ def handle_notification(
     if tty:
         metadata["tty"] = tty
 
-    channel = channel_id("codex", session_id)
+    try:
+        channel = channel_id("codex", session_id)
+    except UnidentifiedSession:
+        _log.warning("dropped a notification with no session id: cwd=%s", cwd)
+        return
 
     # Add to inbox (upsert=True by default, so repeated notifications update timestamp)
     with db.connect() as conn:

--- a/src/lemonaid/inbox/channel.py
+++ b/src/lemonaid/inbox/channel.py
@@ -1,11 +1,24 @@
 """Channel ID construction for lemonaid notifications."""
 
 
+class UnidentifiedSession(Exception):
+    """Raised when a notification carries no session to attribute it to."""
+
+
 def channel_id(backend: str, session_id: str | None) -> str:
     """Build a channel identifier from a backend name and session ID.
 
-    Returns e.g. ``"claude:a1b2c3d4"`` or ``"claude:unknown"`` when
-    session_id is empty.
+    Returns e.g. ``"claude:a1b2c3d4"``.
+
+    Raises `UnidentifiedSession` when there is no session id. A shared
+    placeholder channel looks like one more session in the inbox, and it
+    inherits the tty of whatever shell delivered it - so it lands on a real
+    pane, and the next unidentified notification upserts over it. Every
+    backend's payload carries an id in practice; a missing one means a
+    malformed call, which is worth dropping rather than filing under a
+    pane someone is using.
     """
-    prefix = session_id[:8] if session_id else "unknown"
-    return f"{backend}:{prefix}"
+    if not session_id:
+        raise UnidentifiedSession(f"{backend} notification has no session id")
+
+    return f"{backend}:{session_id[:8]}"

--- a/src/lemonaid/openclaw/notify.py
+++ b/src/lemonaid/openclaw/notify.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from ..config import load_config
 from ..inbox import db
-from ..inbox.channel import channel_id
+from ..inbox.channel import UnidentifiedSession, channel_id
 from ..lemon_watchers import (
     detect_terminal_switch_source,
     get_git_branch,
@@ -159,7 +159,11 @@ def handle_notification(
     if tty:
         metadata["tty"] = tty
 
-    channel = channel_id("openclaw", session_id)
+    try:
+        channel = channel_id("openclaw", session_id)
+    except UnidentifiedSession:
+        _log.warning("dropped a notification with no session id: cwd=%s", cwd)
+        return
 
     with db.connect() as conn:
         db.add(
@@ -310,7 +314,11 @@ def handle_register(session_id: str | None = None, cwd: str | None = None) -> bo
     if branch:
         metadata["git_branch"] = branch
 
-    channel = channel_id("openclaw", session_id)
+    try:
+        channel = channel_id("openclaw", session_id)
+    except UnidentifiedSession:
+        _log.warning("dropped a notification with no session id: cwd=%s", cwd)
+        return False
 
     # Upsert the notification
     with db.connect() as conn:

--- a/src/lemonaid/opencode/notify.py
+++ b/src/lemonaid/opencode/notify.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from ..inbox import db
+from ..inbox.channel import UnidentifiedSession
 from ..lemon_watchers import (
     detect_terminal_switch_source,
     get_git_branch,
@@ -19,8 +20,10 @@ _log = get_logger("opencode.notify")
 
 
 def _channel_for_session(session_id: str | None) -> str:
+    """Raises `UnidentifiedSession` when there is nothing to attribute to."""
     if not session_id:
-        return "opencode:unknown"
+        raise UnidentifiedSession("opencode notification has no session id")
+
     return f"opencode:{session_id}"
 
 
@@ -149,7 +152,11 @@ def handle_notification(
     if tty:
         metadata["tty"] = tty
 
-    channel = _channel_for_session(session_id)
+    try:
+        channel = _channel_for_session(session_id)
+    except UnidentifiedSession:
+        _log.warning("dropped a notification with no session id: cwd=%s", cwd)
+        return
 
     with db.connect() as conn:
         db.add(

--- a/tests/test_unidentified_session.py
+++ b/tests/test_unidentified_session.py
@@ -1,0 +1,80 @@
+"""A notification that cannot name its session is dropped, not filed."""
+
+import json
+
+import pytest
+
+from lemonaid.claude import notify as claude_notify
+from lemonaid.codex import notify as codex_notify
+from lemonaid.inbox import db
+from lemonaid.inbox.channel import UnidentifiedSession, channel_id
+from lemonaid.openclaw import notify as openclaw_notify
+from lemonaid.opencode import notify as opencode_notify
+
+
+def test_a_session_id_becomes_a_channel():
+    assert channel_id("claude", "a1b2c3d4e5f6") == "claude:a1b2c3d4"
+
+
+@pytest.mark.parametrize("missing", ["", None])
+def test_no_session_id_is_refused_rather_than_named_unknown(missing):
+    with pytest.raises(UnidentifiedSession):
+        channel_id("claude", missing)
+
+
+def _rows():
+    with db.connect() as conn:
+        return conn.execute("SELECT channel FROM notifications").fetchall()
+
+
+def test_codex_drops_a_payload_with_no_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+
+    codex_notify.handle_notification(
+        json.dumps({"type": "agent-turn-complete", "cwd": "/tmp", "last-assistant-message": "hi"})
+    )
+
+    assert _rows() == []
+
+
+def test_codex_keeps_a_payload_that_names_its_thread(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+
+    codex_notify.handle_notification(
+        json.dumps(
+            {
+                "type": "agent-turn-complete",
+                "cwd": "/tmp",
+                "thread-id": "01a03bff-a7bb-77a2-9b4d-d63cfe32fd00",
+                "last-assistant-message": "hi",
+            }
+        )
+    )
+
+    assert [r["channel"] for r in _rows()] == ["codex:01a03bff"]
+
+
+def test_claude_drops_a_payload_with_no_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEMONAID_DB", str(tmp_path / "inbox.db"))
+
+    claude_notify.handle_notification(json.dumps({"cwd": "/tmp", "hook_event_name": "Stop"}))
+
+    assert _rows() == []
+
+
+def test_openclaw_refuses_an_unidentified_session():
+    with pytest.raises(UnidentifiedSession):
+        channel_id("openclaw", "")
+
+
+def test_opencode_refuses_an_unidentified_session():
+    with pytest.raises(UnidentifiedSession):
+        opencode_notify._channel_for_session("")
+
+
+def test_opencode_keeps_the_whole_session_id():
+    assert opencode_notify._channel_for_session("abcdefghijkl") == "opencode:abcdefghijkl"
+
+
+def test_openclaw_module_imports_the_guard():
+    assert openclaw_notify.UnidentifiedSession is UnidentifiedSession


### PR DESCRIPTION
🍋:

A notification that can't say which session it came from used to get filed under a shared `unknown` channel — one per backend. That row then picked up the tty of whatever shell delivered it, so it landed in the inbox looking like a session sitting on a real pane, and the next unidentified notification upserted straight over it.

I hit this by accident while debugging something else: two hand-written probe payloads with no session id turned into a card named `/tmp` on a live pane, and the second overwrote the first.

Real payloads always carry an id — Codex sends `thread-id`, Claude sends `session_id` — and the inbox has never recorded an `unknown` channel outside my probes. So this is a latent bug rather than one that's been quietly corrupting anything. The fix treats a missing id as the malformed call it is.

#### What changed

`channel_id` raises `UnidentifiedSession` instead of substituting `"unknown"`. Each hook catches it, logs a warning, and returns without writing a row.

Covers all four backends. `opencode` builds its channel string separately (it keeps the full session id rather than the first 8 chars), so it got the same treatment in place rather than being routed through `channel_id` — changing its format isn't needed for this fix.

Call sites that already guarded on an empty id (`dismiss_session` in three backends, `_entry_to_index_entry` in bootstrap) were left alone.

`handle_register` returns `False` on the drop path, matching the two failure returns it already had.

#### Testing

10 new tests in `tests/test_unidentified_session.py`, including end-to-end cases that replay the exact probe payloads that caused this.

Verified they catch the regression: reverting only the refusal in `channel_id` (keeping the exception class, so imports still resolve) fails 5 of them, including both end-to-end cases.

602 passing. The 4 `test_follow_hook` failures are pre-existing — confirmed by running them on unmodified `main`. The 2 remaining `RUF059` ruff errors are likewise already on `main`.
