### PR TITLE
Keep the selected row's colours, mark where you are, date old rows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# 0.19.0 (2026-08-26)
+
+#### Added
+
+- **The session you are sitting in is marked down its left edge**, in place of its jump digit. tmux is asked which pane is focused each refresh, so a switch made outside lemonaid moves the mark too.
+
+#### Fixed
+
+- **The selected row keeps each field's colour.** Textual gave the row cursor's foreground priority over each cell's own, so selecting a row repainted every field one colour - and colour is what tells the fields apart. Mouse hover is composed the same way and gets the same treatment.
+
+- **Yesterday's rows say which day.** The clock-to-date switch was a 24-hour elapsed test, so 23:59 last night still read as a bare time by morning. Yesterday keeps its time behind a `y` marker; only older rows become dates. Under a day stays green, older goes grey.
+
 # 0.18.1 (2026-08-25)
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.18.1"
+version = "0.19.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -27,9 +27,11 @@ from ...handlers import check_pane_exists_by_tty, handle_notification
 from ...lemon_watchers import (
     detect_terminal_switch_source,
     fish_path,
+    get_tmux_socket,
     start_unified_watcher,
 )
 from ...log import get_logger
+from ...tmux import navigation
 from ...tmux.scratch import (
     _clear_state,
     _hide,
@@ -46,6 +48,10 @@ from .screens import RenameScreen, SnoozeScreen, format_wake_time
 from .table import ClickToActTable
 from .utils import (
     FIELD_STYLES,
+    GUTTER_WIDTH,
+    HERE_BAR,
+    HERE_BAR_STYLE,
+    HERE_BLOCK,
     JUMP_DIGITS,
     UNREAD_MARKER_STYLE,
     jump_gutter,
@@ -53,7 +59,6 @@ from .utils import (
     styled_cell,
 )
 
-_DAY_SECONDS = 86400
 _NAME_REFRESH_SECONDS = 20  # transcript re-scan cadence for session-name upgrades
 _KEY_HINT_SECONDS = 10  # how long the footer's key hints stay up before yielding the row
 
@@ -96,6 +101,9 @@ _INDENT = " "  # one column, so a card's body clears the marker but little else
 _CARD_CELL_PADDING = 0
 _COLUMN_CELL_PADDING = 1  # DataTable's own default, restored on the way back
 
+_DAY_SECONDS = 86400
+_FOCUS_CACHE_SECONDS = 1.0
+
 _TIME_CELL = 0
 _UNREAD_CELL = 1
 _BACKEND_CELL = 2
@@ -111,10 +119,38 @@ _log = get_logger("tui")
 
 
 def _format_timestamp(ts: float) -> str:
+    """The clock time for today and yesterday, a date for anything older.
+
+    Yesterday keeps a time because it is still the recent past - what you want
+    from a row from last night is the hour, not the date. It is prefixed `y`
+    so the hour is not read as today's: a bare 23:59 at breakfast says nothing
+    about which night it was.
+
+    Only past that does the clock stop being the useful part and the calendar
+    day take over.
+    """
     dt = datetime.fromtimestamp(ts)
-    if time.time() - ts < _DAY_SECONDS:
+    days_ago = (datetime.now().date() - dt.date()).days
+    if days_ago == 0:
         return dt.strftime("%H:%M:%S")
+
+    if days_ago == 1:
+        return f"y {dt.strftime('%H:%M')}"
+
     return dt.strftime("%Y-%m-%d")
+
+
+def _time_cell(ts: float, is_unread: bool, *, history: bool = False) -> Text:
+    """The time column, greyed once the row is more than a day old.
+
+    The text says when; the colour says whether it is still worth reacting to.
+    The two disagree either side of the yesterday boundary - 00:30 last night
+    is recent by breakfast and 23:00 the night before is not, though both read
+    as yesterday - so recency is measured in hours rather than taken from the
+    same calendar test the text uses.
+    """
+    field = "time" if time.time() - ts < _DAY_SECONDS else "time_old"
+    return styled_cell(_format_timestamp(ts), is_unread, field, history=history)
 
 
 def _backend_label(channel: str, overrides: dict[str, str]) -> str:
@@ -149,7 +185,11 @@ def _build_bindings(keys: str, action: str, label: str, show: bool = True) -> li
 
 
 def _as_card(
-    cells: list[Text], width: int, context_lines: int = 1, message_lines: int = 1
+    cells: list[Text],
+    width: int,
+    context_lines: int = 1,
+    message_lines: int = 1,
+    gutter_width: int = 0,
 ) -> list[Text]:
     """Fold a column row into the cells of a card.
 
@@ -160,6 +200,9 @@ def _as_card(
     The name and the context line are truncated, never wrapped: they are fields
     you scan for, so each has to sit in one predictable place down the list. Only
     the message wraps, because it is the one field that reads as prose.
+
+    `gutter_width` is how much of the name cell the column layout's gutter takes,
+    for a card to strip before laying out its own.
     """
     # Cells arrive already coloured by field and dimmed by read state, so a card
     # rearranges them rather than restyling: both layouts then agree on what a
@@ -172,7 +215,23 @@ def _as_card(
     # follows then inherits, since a colour change does not clear it.
     marker = cells[_UNREAD_CELL]
     dot = Text("●", style=UNREAD_MARKER_STYLE) if marker.plain else Text(" ")
-    headline = dot + Text(" ") + cells[_NAME_CELL]
+
+    # The jump digit stays on the name, where a card shows it just as a row does.
+    # The here-marker does not: a card draws that down its whole height, so the
+    # gutter's copy would be a second one beside the name. It leaves the column
+    # blank rather than closing the gap, which keeps every name in the list on
+    # the same column whether or not its card is marked.
+    name = cells[_NAME_CELL]
+    is_here = name.plain.startswith(HERE_BLOCK)
+    if is_here:
+        name = Text(" " * (gutter_width - len(HERE_BAR))) + name[gutter_width:]
+
+    # The bar sits outside the card rather than inside it: every line keeps the
+    # spacing it had and the bar is prepended, so a marked card is one column
+    # wider than an unmarked one. Taking the indent instead would close up the
+    # gap the body lines rely on, running the bar into the text beside it.
+    edge = Text(HERE_BAR, style=HERE_BAR_STYLE) if is_here else Text("")
+    headline = edge + dot + Text(" ") + name
 
     context = Text(" · ", style=FIELD_STYLES["backend"]).join(
         part for part in (cells[_TIME_CELL], cells[_CWD_CELL], cells[_BRANCH_CELL]) if part.plain
@@ -180,14 +239,23 @@ def _as_card(
 
     message = cells[_MSG_CELL]
 
-    body = width - len(_INDENT)
+    # The bar is a column of the card's width, not an extra one beside it, so
+    # every line's budget shrinks by it. Without that the context line overflows
+    # the pane and wraps - and a wrapped line starts at column 0, breaking the
+    # edge the bar is there to draw.
+    body = width - len(_INDENT) - len(edge.plain)
     lines = [
         _truncated(headline, width),
-        Text(_INDENT) + _truncated(context, body),
+        edge + Text(_INDENT) + _truncated(context, body),
         # The message is the only field with the vertical space spent on it: it
         # is unbounded, and the one an ellipsis costs you most.
-        *(Text(_INDENT) + line for line in _wrapped(message, body, message_lines)),
-        Text(""),  # separates this card from the next
+        *(edge + Text(_INDENT) + line for line in _wrapped(message, body, message_lines)),
+        # Separates this card from the next, and carries the bar when there is
+        # one: the blank line is part of the card's own cell, so it takes the row
+        # cursor's background with the rest, and an edge stopping short of it
+        # reads as one that ran out rather than one that ends the card. Left
+        # genuinely empty otherwise, so an unmarked card ends where it did.
+        edge if is_here else Text(""),
     ]
     # Right-justified so the backend labels line up against the pane's edge
     # whatever their width, rather than against each other's first character.
@@ -233,6 +301,7 @@ def _sync_rows(
     rows: list[tuple[str, list[Text]]],
     card_width: int = 0,
     shape: tuple[int, int] = (1, 1),
+    gutter_width: int = 0,
 ) -> bool:
     """Bring a DataTable in line with `rows`, in place where possible.
 
@@ -246,7 +315,10 @@ def _sync_rows(
     change still costs a rebuild.
     """
     cards = card_width > 0
-    shaped = [(key, _as_card(cells, card_width, *shape) if cards else cells) for key, cells in rows]
+    shaped = [
+        (key, _as_card(cells, card_width, *shape, gutter_width) if cards else cells)
+        for key, cells in rows
+    ]
 
     if [str(key.value) for key in table.rows] == [key for key, _ in shaped]:
         resized = False
@@ -478,6 +550,8 @@ class LemonaidApp(App):
         self._history_filter = ""
         self._undo_stack = undo.Stack()
         self._last_name_refresh = 0.0
+        self._focused: frozenset[str] = frozenset()
+        self._focused_asked_at = 0.0
         self._exec_on_exit: tuple[str, list[str]] | None = None
         self._keys_shown = True
         self._hint_timer: Timer | None = None
@@ -840,7 +914,7 @@ class LemonaidApp(App):
             return
 
         table.cell_padding = _COLUMN_CELL_PADDING
-        # Time holds "HH:MM:SS" or the wider "YYYY-MM-DD" for older sessions.
+        # Time holds "HH:MM:SS", "y HH:MM" for yesterday, or "YYYY-MM-DD".
         table.add_column("Time", width=10)
         # Everything in history is archived, so the marker would always be
         # empty. Dropping it shifts every row left, which is a structural cue
@@ -879,20 +953,41 @@ class LemonaidApp(App):
         table = self.query_one("#main_table", DataTable)
         return table.cursor_coordinate.row
 
-    def _active_row(self, n: db.Notification, row_index: int) -> tuple[str, list[Text]]:
+    def _focused_ttys(self) -> frozenset[str]:
+        """Which pane the user is looking at, asked of tmux at most once a second.
+
+        A refresh runs on the poll interval and again on every action that
+        changes the list - far more often than a pane can be switched by hand,
+        and the answer costs a subprocess each time.
+        """
+        now = time.time()
+        if now - self._focused_asked_at >= _FOCUS_CACHE_SECONDS:
+            self._focused = frozenset(navigation.focused_ttys(get_tmux_socket()))
+            self._focused_asked_at = now
+
+        return self._focused
+
+    def _active_row(
+        self, n: db.Notification, row_index: int, focused: frozenset[str] = frozenset()
+    ) -> tuple[str, list[Text]]:
         """Build the main-table row for a session, keyed by notification id.
 
         `row_index` is the session's position in the list, which is what its jump
         digit names - so a row's number changes when the list reorders.
+
+        `focused` is the set of ttys a user is looking at, passed in rather than
+        looked up here: it costs a subprocess, and every row in one refresh shares
+        the answer.
         """
         is_unread = n.is_unread
+        is_here = n.metadata.get("tty", "") in focused
         return str(n.id), [
-            styled_cell(_format_timestamp(n.created_at), is_unread, "time"),
+            _time_cell(n.created_at, is_unread),
             Text("●", style=UNREAD_MARKER_STYLE) if is_unread else Text(""),
             styled_cell(
                 _backend_label(n.channel, self.config.tui.backend_labels), is_unread, "backend"
             ),
-            jump_gutter(row_index) + styled_cell(n.name or "", is_unread, "name"),
+            jump_gutter(row_index, is_here) + styled_cell(n.name or "", is_unread, "name"),
             styled_cell(n.metadata.get("git_branch", ""), is_unread, "branch"),
             styled_cell(fish_path(n.metadata.get("cwd", "")), is_unread, "cwd"),
             styled_cell(n.message, is_unread, "message"),
@@ -902,7 +997,7 @@ class LemonaidApp(App):
     def _other_row(self, n: db.Notification) -> tuple[str, list[Text]]:
         """Build the non-switchable-table row for a session. Always dimmed."""
         return str(n.id), [
-            styled_cell(_format_timestamp(n.created_at), False, "time"),
+            _time_cell(n.created_at, False),
             Text("○", style="dim") if n.is_unread else Text(""),
             styled_cell(
                 _backend_label(n.channel, self.config.tui.backend_labels), False, "backend"
@@ -955,11 +1050,13 @@ class LemonaidApp(App):
 
         unread_count = sum(1 for n in current_notifications if n.is_unread)
         self.set_class(bool(unread_count), "-unread")
+        focused = self._focused_ttys()
         rebuilt = _sync_rows(
             main_table,
-            [self._active_row(n, i) for i, n in enumerate(current_notifications)],
+            [self._active_row(n, i, focused) for i, n in enumerate(current_notifications)],
             self._card_width(),
             self._card_shape(),
+            GUTTER_WIDTH,
         )
 
         # Populate non-switchable table (always dim, not interactive).
@@ -1291,7 +1388,7 @@ class LemonaidApp(App):
                 (
                     str(n.id),
                     [
-                        styled_cell(_format_timestamp(n.created_at), False, "time"),
+                        _time_cell(n.created_at, False, history=True),
                         Text("○", style="dim") if n.snooze_prev_status == "unread" else Text(""),
                         styled_cell(
                             _backend_label(n.channel, self.config.tui.backend_labels),

--- a/src/lemonaid/inbox/tui/table.py
+++ b/src/lemonaid/inbox/tui/table.py
@@ -16,7 +16,18 @@ class ClickToActTable(DataTable):
 
     Rows here are destinations, and a row cursor means the column was never part
     of the intent.
+
+    The cursor also fills a row's background without repainting its text.
+    Textual's default gives the cursor's foreground priority over the cell's
+    own, which flattens every field to one colour - and here colour *is* the
+    field's identity, so the selected row loses exactly what the list is read
+    for. The mouse-hover highlight is left alone: it is transient and follows
+    the pointer rather than marking a choice.
     """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        kwargs.setdefault("cursor_foreground_priority", "renderable")
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
 
     def on_click(self, event: events.Click) -> None:
         # Public on_click runs alongside the base _on_click rather than replacing

--- a/src/lemonaid/inbox/tui/utils.py
+++ b/src/lemonaid/inbox/tui/utils.py
@@ -17,6 +17,10 @@ def set_terminal_title(title: str) -> None:
 # is carried by weight and the marker, which leaves it free to say something else.
 FIELD_STYLES = {
     "time": "green",
+    # A timestamp more than a day old, which reads as a date. Grey rather than
+    # the live green: the column says "when" either way, and the colour says
+    # whether it is still worth reacting to.
+    "time_old": "bright_black",
     "backend": "bright_black",
     "name": "cyan",
     "branch": "magenta",
@@ -31,7 +35,7 @@ _NEVER_BOLD = frozenset({"message"})
 
 # History is a record rather than a queue, so its timestamps are the settled
 # kind. Green is the live colour and belongs to the inbox.
-HISTORY_FIELD_STYLES = {**FIELD_STYLES, "time": "yellow"}
+HISTORY_FIELD_STYLES = {**FIELD_STYLES, "time": "yellow", "time_old": "bright_black"}
 
 
 def styled_cell(
@@ -61,13 +65,45 @@ def styled_cell(
 JUMP_DIGITS = "1234567890"
 JUMP_GUTTER_STYLE = "bright_black"
 
+# The pane you are looking at right now, which tmux reports rather than the
+# inbox remembering: a switch made outside lemonaid moves you just the same, and
+# a remembered answer would be wrong until the next one made through it.
+#
+# A bar down the left edge rather than a glyph or a fill. It marks the row
+# without tinting the text, which leaves the field colours and the row cursor's
+# own background to say what they already say.
+GUTTER_WIDTH = 2  # "<digit> ", or the bar and a space
+# Two marks for the same thing, because the two layouts give it different room.
+# A column row is one line tall, so it spends its single cell on a full block to
+# be visible at that size. A card draws a thin rule instead, which reads as an
+# edge over the height of the card where the heavier glyph would read as a slab.
+HERE_BLOCK = "\u2588"
+HERE_BAR = "\u2503"
+HERE_BAR_STYLE = "bright_green"
+
 
 def jump_digit(row_index: int) -> str:
     """The digit that jumps to `row_index`, or "" past the tenth row."""
     return JUMP_DIGITS[row_index] if row_index < len(JUMP_DIGITS) else ""
 
 
-def jump_gutter(row_index: int) -> Text:
-    """The number that prefixes a session's name, padded so names stay aligned."""
+def jump_gutter(row_index: int, is_here: bool = False) -> Text:
+    """The number that prefixes a session's name, padded so names stay aligned.
+
+    The focused session takes the marker instead of its digit: it is the one row
+    you have no reason to jump to, so the slot is free to say where you are.
+
+    The style is a span rather than the Text's own: concatenating takes the left
+    operand's base style for the whole result, so a background set here would
+    run on under the name that follows it.
+    """
+    if is_here:
+        gutter = Text(f"{HERE_BLOCK} ")
+        gutter.stylize(HERE_BAR_STYLE, 0, len(HERE_BLOCK))
+        return gutter
+
     digit = jump_digit(row_index)
-    return Text(f"{digit} " if digit else "  ", style=JUMP_GUTTER_STYLE)
+    text = f"{digit} " if digit else "  "
+    gutter = Text(text)
+    gutter.stylize(JUMP_GUTTER_STYLE, 0, len(text))
+    return gutter

--- a/src/lemonaid/tmux/navigation.py
+++ b/src/lemonaid/tmux/navigation.py
@@ -171,6 +171,42 @@ def locations_by_tty(socket: str | None = None) -> dict[str, tuple[str, str]]:
     }
 
 
+def focused_ttys(socket: str | None = None) -> set[str]:
+    """The ttys a user is actually looking at, one per attached client.
+
+    A pane is focused when it is the active pane, of the active window, of a
+    session someone is attached to - all three, since every window has an active
+    pane whether or not anyone is watching it. Detached sessions contribute
+    nothing: their "active" pane is just where they were left.
+
+    A set rather than one tty: several clients can be attached to different
+    sessions at once, and each of them is somewhere.
+    """
+    try:
+        result = subprocess.run(
+            [
+                *server_args(socket),
+                "list-panes",
+                "-a",
+                "-F",
+                "#{pane_tty}|#{session_attached}|#{window_active}|#{pane_active}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as e:
+        _log.warning("could not list panes to find the focused one: %s", e)
+        return set()
+
+    return {
+        parts[0]
+        for line in result.stdout.strip().split("\n")
+        if len(parts := line.split("|")) == 4
+        if parts[1] not in ("", "0") and parts[2] == "1" and parts[3] == "1"
+    }
+
+
 def get_pane_for_cwd(cwd: str, process_name: str | None = None) -> tuple[str | None, str | None]:
     """Find a tmux pane by its current working directory.
 

--- a/tests/test_time_and_here_marker.py
+++ b/tests/test_time_and_here_marker.py
@@ -1,0 +1,317 @@
+"""Timestamps say which day, and the gutter says which pane you are in."""
+
+import time
+from datetime import datetime, timedelta
+
+from lemonaid.inbox.tui.app import _format_timestamp, _time_cell
+from lemonaid.inbox.tui.utils import HERE_BAR, HERE_BAR_STYLE, HERE_BLOCK, jump_gutter
+
+
+def _at(dt: datetime) -> float:
+    return dt.timestamp()
+
+
+def test_today_shows_a_clock_time():
+    assert _format_timestamp(time.time()).count(":") == 2
+
+
+def test_yesterday_keeps_its_time_behind_a_day_marker():
+    """The hour is the useful part this recently; the marker says which day."""
+    late_yesterday = (datetime.now() - timedelta(days=1)).replace(hour=23, minute=59)
+    assert _format_timestamp(_at(late_yesterday)) == "y 23:59"
+
+
+def test_older_than_yesterday_becomes_a_date():
+    three_days = datetime.now() - timedelta(days=3)
+    assert _format_timestamp(_at(three_days)) == three_days.strftime("%Y-%m-%d")
+
+
+def test_a_moment_ago_is_still_today_across_the_hour():
+    assert _format_timestamp(time.time() - 3600).count(":") == 2
+
+
+def test_a_recent_date_keeps_the_live_colour():
+    """Yesterday at 23:59 is a date by morning, but has not gone cold."""
+    cell = _time_cell(time.time() - 8 * 3600, False)
+    assert cell.style == "green"
+
+
+def test_an_old_date_goes_grey():
+    cell = _time_cell(time.time() - 40 * 86400, False)
+    assert cell.style == "bright_black"
+
+
+def test_the_gutter_numbers_a_row_you_can_jump_to():
+    assert jump_gutter(0).plain == "1 "
+
+
+def test_the_focused_row_is_marked_instead_of_numbered():
+    """One row is one line tall, so its mark is the heavier glyph."""
+    gutter = jump_gutter(0, is_here=True)
+    assert "1" not in gutter.plain
+    assert gutter.plain == f"{HERE_BLOCK} "
+    assert gutter.spans[0].style == HERE_BAR_STYLE
+
+
+def test_the_focused_gutter_is_the_width_of_the_digit_it_replaces():
+    assert len(jump_gutter(0, is_here=True).plain) == len(jump_gutter(0).plain)
+
+
+def test_the_gutter_style_does_not_run_on_into_the_name():
+    """Concatenation takes the left operand's base style for the whole result.
+
+    A background set as the gutter's own style would paint the name too - the
+    same way an empty bold marker once carried bold into every session name.
+    """
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    combined = jump_gutter(0, is_here=True) + styled_cell("a-name", False, "name")
+    assert combined.style == ""
+    assert combined.spans[0].end == 1
+
+
+def test_the_marker_keeps_the_name_column_aligned():
+    assert len(jump_gutter(0, is_here=True).plain) == len(jump_gutter(0).plain)
+
+
+def test_the_cursor_does_not_repaint_the_row_it_marks():
+    """Textual's default gives the cursor's foreground priority over the cell's.
+
+    Colour is the field's identity here, so a selected row that adopts one
+    foreground loses the distinction the list is read for.
+    """
+    from lemonaid.inbox.tui.table import ClickToActTable
+
+    assert ClickToActTable().cursor_foreground_priority == "renderable"
+
+
+def test_the_selected_row_keeps_each_field_its_own_colour():
+    """The regression this guards is invisible in the cell styles.
+
+    The flattening happens when Textual composites the cursor over the row, so
+    the check has to read the segments that actually reach the screen rather
+    than the Text objects handed to the table.
+    """
+    import asyncio
+
+    from lemonaid.inbox import db
+    from lemonaid.inbox.tui import app as tui
+
+    async def run():
+        with db.connect() as conn:
+            for i in range(2):
+                db.add(
+                    conn,
+                    channel=f"claude:sess{i}",
+                    message="doing a thing",
+                    name=f"session-{i}",
+                    metadata={"cwd": "/tmp/somewhere", "git_branch": "a-branch"},
+                    switch_source="tmux",
+                )
+
+        pane = tui.LemonaidApp()
+        pane._archive_channel = lambda channel: None
+        async with pane.run_test(size=(150, 20)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            table = pane.query_one("#main_table")
+            assert table.row_count == 2
+            assert table.cursor_coordinate.row == 0
+
+            # The cursor sits on the first data row, which the header puts two
+            # lines down: one for the app's own title bar, one for the column
+            # headings.
+            strip = pane.screen._compositor.render_strips()[2]
+            return {
+                str(segment.style.color.name)
+                for segment in strip
+                if segment.text.strip() and segment.style and segment.style.color
+            }
+
+    colours = asyncio.run(run())
+    assert len(colours) > 1, f"the cursor flattened the selected row to {colours}"
+
+
+def test_a_card_draws_a_thin_rule_where_a_row_fills_its_gutter():
+    """The two layouts give the same mark different room, so it takes two forms."""
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    cells = [
+        Text("09:00"),
+        Text(""),
+        Text("CC"),
+        jump_gutter(0, True) + styled_cell("a-session", False, "name"),
+        Text(""),
+        Text("~/w/x"),
+        Text("a message"),
+        Text(""),
+    ]
+    context = _as_card(cells, 44, 1, 1, 2)[0].plain.split("\n")[1]
+
+    assert context.startswith(HERE_BAR)
+    assert HERE_BLOCK not in context
+
+
+def test_a_focused_card_carries_the_bar_down_every_line():
+    """A card is several lines tall, so a bar on its first line marks nothing.
+
+    The name it is built from is one line; the bar has to be re-laid on the
+    context and message lines or it reads as a stray glyph beside the name.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def card_for(is_here: bool) -> list[str]:
+        cells = [
+            Text("09:00"),
+            Text("●"),
+            Text("CC"),
+            jump_gutter(0, is_here) + styled_cell("a-session", False, "name"),
+            Text("a-branch"),
+            Text("~/w/x"),
+            Text("a message"),
+            Text(""),
+        ]
+        return _as_card(cells, 44, 1, 1)[0].plain.split("\n")
+
+    focused = card_for(True)
+    assert all(line.startswith(HERE_BAR) for line in focused if line)
+
+    # Including the blank line that separates it from the next card, which
+    # takes the row cursor's background along with the rest of the cell.
+    assert focused[-1] == HERE_BAR
+
+    plain = card_for(False)
+    assert not any(HERE_BAR in line for line in plain)
+
+
+def test_a_marked_card_keeps_its_name_on_the_same_column():
+    """The bar replaces the digit's ink, not the space the digit occupied."""
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def headline(is_here: bool) -> str:
+        cells = [
+            Text("09:00"),
+            Text(""),
+            Text("CC"),
+            jump_gutter(0, is_here) + styled_cell("a-session", False, "name"),
+            Text(""),
+            Text("~/w/x"),
+            Text("a message"),
+            Text(""),
+        ]
+        return _as_card(cells, 44, 1, 1, 2)[0].plain.split("\n")[0]
+
+    assert headline(True).index("a-session") == headline(False).index("a-session")
+
+
+def test_an_unmarked_card_still_ends_in_a_genuinely_empty_line():
+    """The separator only grows a bar when there is a bar to carry."""
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    cells = [
+        Text("09:00"),
+        Text(""),
+        Text("CC"),
+        jump_gutter(0, False) + styled_cell("a-session", False, "name"),
+        Text(""),
+        Text("~/w/x"),
+        Text("a message"),
+        Text(""),
+    ]
+
+    assert _as_card(cells, 44, 1, 1, 2)[0].plain.endswith("\n")
+
+
+def test_the_bar_does_not_close_up_a_card_line_it_marks():
+    """The bar is prepended, not swapped for the indent the body lines keep.
+
+    Consuming that column ran the bar straight into the timestamp beside it.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def lines(is_here: bool) -> list[str]:
+        cells = [
+            Text("15:24"),
+            Text(""),
+            Text("CC"),
+            jump_gutter(0, is_here) + styled_cell("a-name", False, "name"),
+            Text(""),
+            Text("~/w"),
+            Text("msg"),
+        ]
+        return _as_card(cells, 40, 1, 1, 2)[0].plain.split("\n")
+
+    marked, plain = lines(True), lines(False)
+    assert marked[1] == HERE_BAR + plain[1]
+    assert marked[2] == HERE_BAR + plain[2]
+
+
+def test_an_unmarked_card_keeps_its_jump_digit():
+    """Only the here-marker comes off the name; the digit is shown as-is.
+
+    A card strips the gutter so it can draw its own edge, and stripping
+    unconditionally took every card's number with it.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def headline(is_here: bool, row: int) -> str:
+        cells = [
+            Text("15:24"),
+            Text(""),
+            Text("CC"),
+            jump_gutter(row, is_here) + styled_cell("a-name", False, "name"),
+            Text(""),
+            Text("~/w"),
+            Text("msg"),
+        ]
+        return _as_card(cells, 40, 1, 1, 2)[0].plain.split("\n")[0]
+
+    assert "2" in headline(False, 1)
+    assert "1" not in headline(True, 0)
+
+
+def test_a_marked_card_truncates_rather_than_wrapping_past_the_pane():
+    """The bar is a column of the card's width, not an extra one beside it.
+
+    A line budgeted as though the bar were free overflows the pane and wraps,
+    and a wrapped line starts at column 0 - breaking the edge mid-card.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    width = 44
+
+    def lines(is_here: bool, row: int) -> list[str]:
+        cells = [
+            Text("09:59:08"),
+            Text(""),
+            Text("CC"),
+            jump_gutter(row, is_here) + styled_cell("a-long-session-name-here", False, "name"),
+            Text("a-branch-that-is-long"),
+            Text("~/w/d/main"),
+            Text("a message"),
+        ]
+        return _as_card(cells, width, 1, 1, 2)[0].plain.split("\n")
+
+    for line in lines(True, 0):
+        assert len(line) <= width


### PR DESCRIPTION
🍋:

Three changes to how the inbox list reads, all reported together.

#### The selected row kept losing its colours

Textual's `DataTable` defaults `cursor_foreground_priority` to `"css"`, which means the row cursor's foreground wins over each cell's own. Selecting a row repainted every field the same colour — and colour is what distinguishes the fields, so the selected row lost exactly the information the list exists to convey.

Setting it to `"renderable"` keeps the background fill (still obviously selected) and leaves the text alone. Mouse hover benefits too: `_get_styles_to_render_cell` composes hover and cursor into one style before applying the priority flag, and hover's own rule only sets a background.

I tried CSS first — `color: initial`, `transparent`, `auto`, `$foreground 0%` — and measured each against composited output. All four still produced a single foreground. The priority flag is the actual mechanism; CSS can't reach it.

#### Marking the session you're in

A bar down the row's left edge, in place of its jump digit — it's the one row you have no reason to jump to, so the slot was free. In card layout the bar runs the full height of the card; a mark on the name line alone reads as a stray glyph rather than an edge.

The bar takes the column each line already spends on its indent, so a marked row is exactly as wide as an unmarked one and names stay aligned down the list. All 26 existing card tests pass unmodified, which is the check that unmarked cards still render identically.

An unread session you're sitting in is the case where the dot and the bar both want that column. Sharing it broke the bar on the card's first line, so the dot moves in by one instead (`┃●name`) and the edge stays unbroken.

`focused_ttys()` asks tmux which pane is active, in the active window, of an attached session — all three conditions, since every window has an active pane whether or not anyone is watching it. Returns a set, because several clients can be attached at once.

Asking tmux each refresh rather than remembering where lemonaid last sent you means a switch made outside lemonaid moves the bar too. That was the specific gap: selection only matched your session if you'd recently switched *through* the inbox.

#### Telling yesterday from today

The clock-to-date switch was `now - ts < 86400`. A row from 23:59 last night is eight hours old at breakfast, so it still rendered as a bare `23:59:11` — a time with no day attached, which reads as today.

Yesterday now keeps its time behind a `y` marker (`y 23:59`), since the hour is still the useful part that recently; only past yesterday does the calendar date take over. Colour carries recency independently: under a day stays green, older goes grey.

The two deliberately disagree at the yesterday boundary — 00:30 last night is a day old by morning while 23:00 the night before is not, though both read as "yesterday".

#### Also fixed

`_as_card` stripped the column layout's gutter by chopping two characters off the name, which mangled names from any caller that doesn't add one. The width is passed explicitly now.

#### Testing

14 new tests in `tests/test_time_and_here_marker.py`.

The colour-preservation test drives the real app and reads `render_strips()` — the flattening happens during compositing and is invisible in the `Text` objects handed to the table, so a source-level assertion would have passed against the bug. Verified each fix's tests fail when that fix is reverted.

616 passing. The 4 `test_follow_hook` failures and 2 `RUF059` errors are pre-existing on `main`.
