### PR TITLE
Put the here-marker in the card's padding column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.19.1 (2026-08-26)
+
+#### Fixed
+
+- **Marking a card no longer moves what is in it.** The bar was prepended to each line rather than placed in the column the card already spends on padding, so a card shifted right by one the moment it became the focused session - which read as the list jumping under the cursor. The unread dot moves into the cell the jump digit vacated, since the row you are already in is the one a number is no use on.
+
 # 0.19.0 (2026-08-26)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.19.0"
+version = "0.19.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -221,17 +221,22 @@ def _as_card(
     # gutter's copy would be a second one beside the name. It leaves the column
     # blank rather than closing the gap, which keeps every name in the list on
     # the same column whether or not its card is marked.
+    # The jump digit comes off a marked name - the card draws the bar down its
+    # own edge instead of carrying the gutter's copy of it.
     name = cells[_NAME_CELL]
     is_here = name.plain.startswith(HERE_BLOCK)
     if is_here:
-        name = Text(" " * (gutter_width - len(HERE_BAR))) + name[gutter_width:]
+        name = name[gutter_width:]
 
-    # The bar sits outside the card rather than inside it: every line keeps the
-    # spacing it had and the bar is prepended, so a marked card is one column
-    # wider than an unmarked one. Taking the indent instead would close up the
-    # gap the body lines rely on, running the bar into the text beside it.
-    edge = Text(HERE_BAR, style=HERE_BAR_STYLE) if is_here else Text("")
-    headline = edge + dot + Text(" ") + name
+    # The bar goes in the column every line already spends on padding, rather
+    # than before it. Prepending would push the whole card right by one the
+    # moment it was marked, which reads as the list jumping under the cursor.
+    #
+    # That leaves the dot nowhere to sit on a marked card, so it takes the cell
+    # the jump digit vacated: the row it marks is the one you are already in,
+    # which is the one row a number would be no use on.
+    edge = Text(HERE_BAR, style=HERE_BAR_STYLE) if is_here else Text(_INDENT)
+    headline = edge + Text(" ") + dot + Text(" ") + name if is_here else dot + Text(" ") + name
 
     context = Text(" · ", style=FIELD_STYLES["backend"]).join(
         part for part in (cells[_TIME_CELL], cells[_CWD_CELL], cells[_BRANCH_CELL]) if part.plain
@@ -243,13 +248,13 @@ def _as_card(
     # every line's budget shrinks by it. Without that the context line overflows
     # the pane and wraps - and a wrapped line starts at column 0, breaking the
     # edge the bar is there to draw.
-    body = width - len(_INDENT) - len(edge.plain)
+    body = width - len(_INDENT)
     lines = [
         _truncated(headline, width),
-        edge + Text(_INDENT) + _truncated(context, body),
+        edge + _truncated(context, body),
         # The message is the only field with the vertical space spent on it: it
         # is unbounded, and the one an ellipsis costs you most.
-        *(edge + Text(_INDENT) + line for line in _wrapped(message, body, message_lines)),
+        *(edge + line for line in _wrapped(message, body, message_lines)),
         # Separates this card from the next, and carries the bar when there is
         # one: the blank line is part of the card's own cell, so it takes the row
         # cursor's background with the rest, and an edge stopping short of it

--- a/tests/test_time_and_here_marker.py
+++ b/tests/test_time_and_here_marker.py
@@ -234,31 +234,35 @@ def test_an_unmarked_card_still_ends_in_a_genuinely_empty_line():
     assert _as_card(cells, 44, 1, 1, 2)[0].plain.endswith("\n")
 
 
-def test_the_bar_does_not_close_up_a_card_line_it_marks():
-    """The bar is prepended, not swapped for the indent the body lines keep.
+def test_marking_a_card_does_not_move_anything_in_it():
+    """The bar goes in the column the card already spends on padding.
 
-    Consuming that column ran the bar straight into the timestamp beside it.
+    Prepending it instead pushed every line right by one the moment a card was
+    marked, which reads as the list jumping under the cursor.
     """
     from rich.text import Text
 
     from lemonaid.inbox.tui.app import _as_card
     from lemonaid.inbox.tui.utils import styled_cell
 
-    def lines(is_here: bool) -> list[str]:
+    def lines(is_here: bool, row: int) -> list[str]:
         cells = [
             Text("15:24"),
             Text(""),
             Text("CC"),
-            jump_gutter(0, is_here) + styled_cell("a-name", False, "name"),
+            jump_gutter(row, is_here) + styled_cell("a-name", False, "name"),
             Text(""),
             Text("~/w"),
             Text("msg"),
         ]
         return _as_card(cells, 40, 1, 1, 2)[0].plain.split("\n")
 
-    marked, plain = lines(True), lines(False)
-    assert marked[1] == HERE_BAR + plain[1]
-    assert marked[2] == HERE_BAR + plain[2]
+    marked, plain = lines(True, 0), lines(False, 2)
+
+    assert marked[0].index("a-name") == plain[0].index("a-name")
+    assert marked[1].index("15:24") == plain[1].index("15:24")
+    assert marked[1][0] == HERE_BAR
+    assert plain[1][0] == " "
 
 
 def test_an_unmarked_card_keeps_its_jump_digit():
@@ -315,3 +319,33 @@ def test_a_marked_card_truncates_rather_than_wrapping_past_the_pane():
 
     for line in lines(True, 0):
         assert len(line) <= width
+
+
+def test_a_marked_card_puts_its_dot_where_the_digit_would_be():
+    """The bar takes the padding column, leaving the dot the digit's cell.
+
+    Sitting it beside the bar instead gave the headline no space before the dot
+    and two after it.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def headline(is_here: bool, row: int) -> str:
+        cells = [
+            Text("13:06:01"),
+            Text("●"),
+            Text("CC"),
+            jump_gutter(row, is_here) + styled_cell("a-session", False, "name"),
+            Text(""),
+            Text("~/w/x"),
+            Text("a msg"),
+        ]
+        return _as_card(cells, 44, 1, 1, 2)[0].plain.split("\n")[0]
+
+    marked, plain = headline(True, 0), headline(False, 1)
+
+    assert marked.index("●") == plain.index("●") + 2
+    assert marked.index("a-session") == plain.index("a-session")
+    assert marked[marked.index("●") - 1] == " "


### PR DESCRIPTION
🍋:

Marking a card moved everything in it right by one column, which reads as the list jumping the moment the focused session changes.

The bar was being prepended to each line — `edge + _INDENT + text` — rather than placed in the column every line already spends on padding. Cards have a one-column indent on their body lines; the bar belongs *in* it, not before it.

Now `edge` is the indent: the bar when the card is marked, a space when it isn't. Every line's text sits on the same column either way, and the name keeps its position because the here-marker's two gutter cells become bar plus blank rather than being dropped.

The width budget goes back to `width - len(_INDENT)`, since the bar no longer adds a column.

#### Testing

Replaced the test that asserted the old prepending behavior with one checking the opposite: name column, body column, and the marker character are all compared between a marked and an unmarked card.

622 passing. The 4 `test_follow_hook` failures and 3 `RUF059` errors are pre-existing on `main`.
