### PR TITLE
Keep a marked card still, and migrate under a lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 0.19.1 (2026-08-26)
+
+#### Fixed
+
+- **Marking a card no longer moves what is in it.** The bar was prepended to each line rather than placed in the column the card already spends on padding, so a card shifted right by one the moment it became the focused session. The unread dot moves into the cell the jump digit vacated, since the row you are already in is the one a number is no use on.
+
+- **Two connections no longer run the same migration at once.** Every `connect()` migrates, and the TUI connects from its watcher thread while the main thread is doing the same - both read the same pending version and both applied it, the second failing on a column the first had already renamed.
+
 # 0.19.0 (2026-08-26)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.19.0"
+version = "0.19.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/notify.py
+++ b/src/lemonaid/claude/notify.py
@@ -278,7 +278,7 @@ def handle_submit(stdin_data: str | None = None) -> None:
         data = {}
 
     try:
-        channel, session_id, name, switch_source, metadata = _resolve_session(data, "working")
+        channel, _session_id, name, switch_source, metadata = _resolve_session(data, "working")
     except UnidentifiedSession:
         _log.warning("dropped a working notification with no session id")
         return
@@ -394,7 +394,7 @@ def handle_notification(stdin_data: str | None = None) -> None:
     message, tells_us_what_was_said = _describe(notification_type, shorten_path(cwd))
 
     try:
-        channel, session_id, name, switch_source, metadata = _resolve_session(
+        channel, _session_id, name, switch_source, metadata = _resolve_session(
             data, notification_type
         )
     except UnidentifiedSession:

--- a/src/lemonaid/inbox/migrations/__init__.py
+++ b/src/lemonaid/inbox/migrations/__init__.py
@@ -10,7 +10,26 @@ Each migration module should have:
 import importlib
 import pkgutil
 import sqlite3
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def _exclusive(conn: sqlite3.Connection) -> Iterator[None]:
+    """Hold a write lock for the block, so no other connection can migrate too.
+
+    `PRAGMA user_version` is not transactional, but the lock is what matters:
+    the second connection waits, and by the time it reads the version the first
+    has finished and committed.
+    """
+    conn.execute("BEGIN EXCLUSIVE")
+    try:
+        yield
+    except BaseException:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
 
 
 def get_current_version(conn: sqlite3.Connection) -> int:
@@ -46,16 +65,21 @@ def run_migrations(conn: sqlite3.Connection) -> list[str]:
     """Run any pending migrations.
 
     Returns list of descriptions of migrations that were run.
-    """
-    current_version = get_current_version(conn)
-    migrations = discover_migrations()
-    applied = []
 
-    for version, description, migrate_fn in migrations:
-        if version > current_version:
-            migrate_fn(conn)
-            set_version(conn, version)
-            conn.commit()
-            applied.append(f"v{version}: {description}")
+    Every `connect()` calls this, and the TUI connects from its watcher thread
+    while the main thread is doing the same - so the version is read and written
+    inside one exclusive transaction. Reading it outside, both connections saw
+    the same pending migration and both applied it, and the second failed on a
+    column the first had already renamed.
+    """
+    with _exclusive(conn):
+        current_version = get_current_version(conn)
+        applied = []
+
+        for version, description, migrate_fn in discover_migrations():
+            if version > current_version:
+                migrate_fn(conn)
+                set_version(conn, version)
+                applied.append(f"v{version}: {description}")
 
     return applied

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -221,17 +221,22 @@ def _as_card(
     # gutter's copy would be a second one beside the name. It leaves the column
     # blank rather than closing the gap, which keeps every name in the list on
     # the same column whether or not its card is marked.
+    # The jump digit comes off a marked name - the card draws the bar down its
+    # own edge instead of carrying the gutter's copy of it.
     name = cells[_NAME_CELL]
     is_here = name.plain.startswith(HERE_BLOCK)
     if is_here:
-        name = Text(" " * (gutter_width - len(HERE_BAR))) + name[gutter_width:]
+        name = name[gutter_width:]
 
-    # The bar sits outside the card rather than inside it: every line keeps the
-    # spacing it had and the bar is prepended, so a marked card is one column
-    # wider than an unmarked one. Taking the indent instead would close up the
-    # gap the body lines rely on, running the bar into the text beside it.
-    edge = Text(HERE_BAR, style=HERE_BAR_STYLE) if is_here else Text("")
-    headline = edge + dot + Text(" ") + name
+    # The bar goes in the column every line already spends on padding, rather
+    # than before it. Prepending would push the whole card right by one the
+    # moment it was marked, which reads as the list jumping under the cursor.
+    #
+    # That leaves the dot nowhere to sit on a marked card, so it takes the cell
+    # the jump digit vacated: the row it marks is the one you are already in,
+    # which is the one row a number would be no use on.
+    edge = Text(HERE_BAR, style=HERE_BAR_STYLE) if is_here else Text(_INDENT)
+    headline = edge + Text(" ") + dot + Text(" ") + name if is_here else dot + Text(" ") + name
 
     context = Text(" · ", style=FIELD_STYLES["backend"]).join(
         part for part in (cells[_TIME_CELL], cells[_CWD_CELL], cells[_BRANCH_CELL]) if part.plain
@@ -243,13 +248,13 @@ def _as_card(
     # every line's budget shrinks by it. Without that the context line overflows
     # the pane and wraps - and a wrapped line starts at column 0, breaking the
     # edge the bar is there to draw.
-    body = width - len(_INDENT) - len(edge.plain)
+    body = width - len(_INDENT)
     lines = [
         _truncated(headline, width),
-        edge + Text(_INDENT) + _truncated(context, body),
+        edge + _truncated(context, body),
         # The message is the only field with the vertical space spent on it: it
         # is unbounded, and the one an ellipsis costs you most.
-        *(edge + Text(_INDENT) + line for line in _wrapped(message, body, message_lines)),
+        *(edge + line for line in _wrapped(message, body, message_lines)),
         # Separates this card from the next, and carries the bar when there is
         # one: the blank line is part of the card's own cell, so it takes the row
         # cursor's background with the rest, and an edge stopping short of it

--- a/tests/test_follow_hook.py
+++ b/tests/test_follow_hook.py
@@ -166,10 +166,21 @@ def test_the_switch_target_keeps_focus(tmux):
     assert tmux("display", "-p", "#{pane_id}").stdout.strip() != scratch._get_pane_id()
 
 
+def _where_the_client_is(run) -> str:
+    """The attached client's window.
+
+    Asked of the client rather than of `display` with no target: $TMUX carries a
+    pane id as its third field, and the fixture has no real pane to name there,
+    so tmux resolves "current" to whichever session owns %0 - the parking
+    session - however the client has since been switched.
+    """
+    return run("list-clients", "-F", "#{session_name}:#{window_index}").stdout.strip()
+
+
 def _assert_sane(run, pane: str) -> None:
     """The pane is in the client's window, every window holds at most one slot
     (the pane or a placeholder), and no slot outside the parking session has focus."""
-    here = run("display", "-p", "#{session_name}:#{window_index}").stdout.strip()
+    here = _where_the_client_is(run)
     assert (
         run("display", "-p", "-t", pane, "#{session_name}:#{window_index}").stdout.strip() == here
     )

--- a/tests/test_inbox_cards.py
+++ b/tests/test_inbox_cards.py
@@ -225,7 +225,7 @@ def test_a_card_row_still_fits_when_the_pane_is_tiny():
     """The body has a floor, so a very narrow pane overflows rather than
     rendering a negative width - but it must not do so silently at usual sizes."""
     for width in (40, 45, 50, 58, 64, 70):
-        widths, rendered, hbar = _card_columns(width, 30)
+        _widths, rendered, hbar = _card_columns(width, 30)
         assert not hbar, width
         assert rendered == width - 2, width
 

--- a/tests/test_time_and_here_marker.py
+++ b/tests/test_time_and_here_marker.py
@@ -234,31 +234,35 @@ def test_an_unmarked_card_still_ends_in_a_genuinely_empty_line():
     assert _as_card(cells, 44, 1, 1, 2)[0].plain.endswith("\n")
 
 
-def test_the_bar_does_not_close_up_a_card_line_it_marks():
-    """The bar is prepended, not swapped for the indent the body lines keep.
+def test_marking_a_card_does_not_move_anything_in_it():
+    """The bar goes in the column the card already spends on padding.
 
-    Consuming that column ran the bar straight into the timestamp beside it.
+    Prepending it instead pushed every line right by one the moment a card was
+    marked, which reads as the list jumping under the cursor.
     """
     from rich.text import Text
 
     from lemonaid.inbox.tui.app import _as_card
     from lemonaid.inbox.tui.utils import styled_cell
 
-    def lines(is_here: bool) -> list[str]:
+    def lines(is_here: bool, row: int) -> list[str]:
         cells = [
             Text("15:24"),
             Text(""),
             Text("CC"),
-            jump_gutter(0, is_here) + styled_cell("a-name", False, "name"),
+            jump_gutter(row, is_here) + styled_cell("a-name", False, "name"),
             Text(""),
             Text("~/w"),
             Text("msg"),
         ]
         return _as_card(cells, 40, 1, 1, 2)[0].plain.split("\n")
 
-    marked, plain = lines(True), lines(False)
-    assert marked[1] == HERE_BAR + plain[1]
-    assert marked[2] == HERE_BAR + plain[2]
+    marked, plain = lines(True, 0), lines(False, 2)
+
+    assert marked[0].index("a-name") == plain[0].index("a-name")
+    assert marked[1].index("15:24") == plain[1].index("15:24")
+    assert marked[1][0] == HERE_BAR
+    assert plain[1][0] == " "
 
 
 def test_an_unmarked_card_keeps_its_jump_digit():
@@ -315,3 +319,33 @@ def test_a_marked_card_truncates_rather_than_wrapping_past_the_pane():
 
     for line in lines(True, 0):
         assert len(line) <= width
+
+
+def test_a_marked_card_puts_its_dot_where_the_digit_would_be():
+    """The bar takes the padding column, leaving the dot the digit's cell.
+
+    Sitting it beside the bar instead gave the headline no space before the dot
+    and two after it.
+    """
+    from rich.text import Text
+
+    from lemonaid.inbox.tui.app import _as_card
+    from lemonaid.inbox.tui.utils import styled_cell
+
+    def headline(is_here: bool, row: int) -> str:
+        cells = [
+            Text("13:06:01"),
+            Text("●"),
+            Text("CC"),
+            jump_gutter(row, is_here) + styled_cell("a-session", False, "name"),
+            Text(""),
+            Text("~/w/x"),
+            Text("a msg"),
+        ]
+        return _as_card(cells, 44, 1, 1, 2)[0].plain.split("\n")[0]
+
+    marked, plain = headline(True, 0), headline(False, 1)
+
+    assert marked.index("●") == plain.index("●") + 2
+    assert marked.index("a-session") == plain.index("a-session")
+    assert marked[marked.index("●") - 1] == " "


### PR DESCRIPTION
🍋:

Three fixes that were going to collide on the changelog, so they travel together.

#### A marked card jumped

The here-marker bar was prepended to each line rather than placed in the column the card already spends on padding, so a card shifted right by one the moment it became the focused session — the list appearing to jump under the cursor.

The bar goes in that padding column now. That leaves the unread dot nowhere to sit, so it takes the cell the jump digit vacated: the row you're already in is the one row a number is no use on, and this costs no width.

#### The migration race (a product bug)

`sqlite3.OperationalError: no such column: "title"`, intermittently, in whichever test ran alongside a busy one.

Every `connect()` runs migrations, and the TUI connects from its watcher thread while the main thread does the same. `get_current_version` and `set_version` sat outside any transaction, so both connections read the same pending version and both applied the migration — the second dying on a column the first had already renamed.

The read, the migration, and the version write now share one `BEGIN EXCLUSIVE`. This bites in real use too: two connections at startup is exactly what the TUI does.

#### The follow-hook tests (a test bug)

Four tests asserted the followed pane was in the client's window, and got `_lma_scratch:0` where they expected `a:1` — even though the pane had followed correctly.

`_assert_sane` asked bare `display -p` where the client was. `$TMUX` is `<socket>,<pid>,<pane>`, and the fixture sets that last field to a literal `0` because it has no real pane to name, so tmux resolved "current" from pane `%0` — the parking session — regardless of where the client had been switched. The helper asks `list-clients` now.

Product code was never wrong here: it only reads the socket field out of `$TMUX`.

#### Testing

627 passing with zero failures. Eight consecutive full runs came back clean; the migration race previously showed up in roughly one run in four.
