### PR TITLE
Pin a session to a place in the list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+# 0.20.0 (2026-08-26)
+
+#### Added
+
+- **A session can be pinned to a place in the list.** `p` pins the selected session or releases it; shift-up and shift-down move a pin one slot, and both keys are configurable. A pinned session holds its place whatever its status, so an unread pin no longer jumps to the top, and it is marked beside its backend label.
+
+- **`?` opens a key reference.** It replaces the footer's one-row hint strip, which truncated in a sidebar and never showed the `?` it advertised. On a top bar it lays out in two columns, so a short pane does not scroll.
+
+#### Fixed
+
+- **Exiting your last shell ends the session again.** The placeholder left behind held the window open, and follow mode filled it with the inbox. Follow now kills the placeholder rather than the window, so tmux tears down the window and the session itself - where an attached client goes next is `detach-on-destroy`, which is yours to set.
+
+- **The sidebar comes back on attach.** Reattaching changes no window and no session, so neither hook fired and the window kept a blank placeholder until `prefix+l`.
+
 # 0.19.1 (2026-08-26)
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ lemonaid inbox list
 | `m` / `M` | Mark as read / unread |
 | `a` | Archive (remove from list) |
 | `s` / `S` | Snooze session / list snoozed |
+| `p` | Pin session to a place in the list, or unpin it |
+| `Shift`+`↑`/`↓` | Move a pinned session up or down one slot |
 | `z` | Undo the last inbox change |
 | `r` | Rename session (clear to revert to auto-name) |
 | `h` | Toggle session history |
@@ -174,7 +176,7 @@ lemonaid inbox list
 | `f` | Move the scratch pane between top and left |
 | `H` | Save scratch pane size (follow mode, once it has drifted) |
 | `g` | Refresh |
-| `?` | Toggle the key hints |
+| `?` | Show the key reference |
 | `q` / `Escape` | Quit |
 
 All keybindings are configurable. See [docs/keybindings.md](docs/keybindings.md).

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -107,6 +107,9 @@ mark_unread = "M"
 archive = "a"
 snooze = "s"
 snoozed_list = "S"
+pin = "p"
+move_pin_up = "shift+up"
+move_pin_down = "shift+down"
 undo = "z"
 rename = "r"
 tmux_resume = "T"  # spawn tmux session from history
@@ -122,6 +125,13 @@ For example, to use `o` for selecting sessions:
 [tui.keybindings]
 select = "o"
 ```
+
+### Keys that carry a modifier
+
+`move_pin_up` and `move_pin_down` name one key each, written the way Textual
+writes it - `"shift+up"`, `"ctrl+k"`, `"K"`. They are the exception to the rule
+below: their value is a single key name, not a set of one-character
+alternatives. Set either to `""` to leave it unbound.
 
 ### Multiple keys per action
 

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -128,9 +128,13 @@ meant the window you were returning to was full width until the hook ran, and it
 program repainted in front of you. The first visit to a window is the only time
 its layout changes: a placeholder is split in and the scratch pane swapped into it.
 
-A window whose real panes have all exited, leaving only a placeholder, is closed -
-unless it is its session's last window, since with `detach-on-destroy` that would
-detach you. Flipping position or turning follow off removes every placeholder; the
+When a window's real panes have all exited, the placeholder left behind is killed.
+The window then has nothing in it, so tmux closes it, and a session with no windows
+follows - which means exiting your last shell ends the session as it would without
+follow mode. Where an attached client goes next is `detach-on-destroy`, which is
+yours to set: `off` switches it to another session rather than detaching it.
+
+Flipping position or turning follow off removes every placeholder; the
 saved size is re-asserted whenever a window is resized, so a font change costs the
 window's own panes columns rather than the sidebar.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.19.1"
+version = "0.20.0"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/config.py
+++ b/src/lemonaid/config.py
@@ -84,6 +84,11 @@ class KeybindingsConfig:
     history: str = "h"  # Toggle history view
     copy_resume: str = "c"  # Copy resume command to clipboard
     tmux_resume: str = "T"  # Spawn tmux session around a history entry
+    pin: str = "p"  # Pin a session to a fixed place in the list, or unpin it
+    # Unlike the fields above, these two name one key each rather than a set of
+    # single-character alternatives, so that they can carry a modifier.
+    move_pin_up: str = "shift+up"
+    move_pin_down: str = "shift+down"
     save_size: str = "H"  # Save the scratch pane size (follow mode only)
     flip_position: str = "f"  # Move the scratch pane between top and left
     # Digits 1-9 then 0 switch to that row of the list, counting from the top.

--- a/src/lemonaid/inbox/db.py
+++ b/src/lemonaid/inbox/db.py
@@ -165,11 +165,19 @@ _HIDDEN_STATUSES = ("archived", "snoozed")
 
 
 def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> list[Notification]:
-    """Get active sessions (one per channel), unread first then by recency.
+    """Get active sessions (one per channel), pinned first, then unread, then by recency.
 
     Returns only the most recent notification per channel, excluding archived
     and snoozed ones. If switch_source is provided, filters to only
     notifications with that exact source.
+
+    A pinned session holds its place whatever its status, so an unread pin
+    stays where it was put rather than rising to the top. Unpinned sessions sort
+    as they always did, below every pin.
+
+    The channel is last, and has to stay there. It is only a tiebreak for two
+    pins that somehow share a position - above the status test it sorts every
+    unpinned row too, since those all tie on a NULL position.
 
     Callers that render the inbox should call wake_expired() first; this query
     does not itself resurrect sessions whose snooze has run out.
@@ -184,11 +192,15 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
                 WHERE status NOT IN ('archived', 'snoozed')
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
+            LEFT JOIN pins p ON p.channel = n.channel
             WHERE n.status NOT IN ('archived', 'snoozed')
             AND n.switch_source = ?
             ORDER BY
+                CASE WHEN p.position IS NULL THEN 1 ELSE 0 END,
+                p.position,
                 CASE n.status WHEN 'unread' THEN 0 ELSE 1 END,
-                n.created_at DESC
+                n.created_at DESC,
+                n.channel
             """,
             (switch_source,),
         ).fetchall()
@@ -202,10 +214,14 @@ def get_active(conn: sqlite3.Connection, switch_source: str | None = None) -> li
                 WHERE status NOT IN ('archived', 'snoozed')
                 GROUP BY channel
             ) latest ON n.id = latest.max_id
+            LEFT JOIN pins p ON p.channel = n.channel
             WHERE n.status NOT IN ('archived', 'snoozed')
             ORDER BY
+                CASE WHEN p.position IS NULL THEN 1 ELSE 0 END,
+                p.position,
                 CASE n.status WHEN 'unread' THEN 0 ELSE 1 END,
-                n.created_at DESC
+                n.created_at DESC,
+                n.channel
             """
         ).fetchall()
     return [Notification.from_row(row) for row in rows]
@@ -765,7 +781,12 @@ def mark_unread_by_tty(conn: sqlite3.Connection, tty: str) -> int:
 
 
 def archive(conn: sqlite3.Connection, notification_id: int) -> None:
-    """Archive a notification and all other rows sharing its channel."""
+    """Archive a notification and all other rows sharing its channel.
+
+    Archiving drops any pin on the channel. Snoozing deliberately does not:
+    snooze is "not now" and the session comes back to its place, where archive
+    is "done" and would otherwise leave a pin on a session absent from the list.
+    """
     row = conn.execute(
         "SELECT channel FROM notifications WHERE id = ?", (notification_id,)
     ).fetchone()
@@ -774,6 +795,7 @@ def archive(conn: sqlite3.Connection, notification_id: int) -> None:
             "UPDATE notifications SET status = 'archived' WHERE channel = ?",
             (row["channel"],),
         )
+        conn.execute("DELETE FROM pins WHERE channel = ?", (row["channel"],))
     else:
         conn.execute(
             "UPDATE notifications SET status = 'archived' WHERE id = ?",

--- a/src/lemonaid/inbox/migrations/m005_add_pins.py
+++ b/src/lemonaid/inbox/migrations/m005_add_pins.py
@@ -1,0 +1,24 @@
+"""Add pinned sessions.
+
+A pin belongs to a channel rather than to a notification, so it survives the
+new rows that arrive on that channel. Snooze and archive write across existing
+rows and would leave a fresh notification unpinned.
+
+`position` is REAL so a later insert-between-two-rows has somewhere to go.
+Moving a pin one slot only ever swaps two values, which needs no such room, so
+the values written today are integer-spaced.
+"""
+
+import sqlite3
+
+VERSION = 5
+DESCRIPTION = "Add pins table"
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS pins (
+            channel TEXT PRIMARY KEY,
+            position REAL NOT NULL
+        )
+    """)

--- a/src/lemonaid/inbox/pins.py
+++ b/src/lemonaid/inbox/pins.py
@@ -1,0 +1,66 @@
+"""Pinned sessions: a channel held at a chosen place in the inbox.
+
+Position values are sparse on purpose. A pinned session that is snoozed or
+otherwise absent keeps its number while it is away, so the gaps in a rendered
+list are where the absent pins will return. Nothing compacts them.
+
+Moving a pin swaps two positions and leaves every other row alone, so a pin you
+cannot see is never renumbered by a move you made without it on screen.
+"""
+
+import sqlite3
+
+_SPACING = 10.0
+
+
+def pinned_positions(conn: sqlite3.Connection) -> dict[str, float]:
+    """Every pinned channel and its position."""
+    return {row["channel"]: row["position"] for row in conn.execute("SELECT * FROM pins")}
+
+
+def is_pinned(conn: sqlite3.Connection, channel: str) -> bool:
+    return conn.execute("SELECT 1 FROM pins WHERE channel = ?", (channel,)).fetchone() is not None
+
+
+def pin(conn: sqlite3.Connection, channel: str) -> None:
+    """Pin a channel below every existing pin. Pinning twice does nothing."""
+    if is_pinned(conn, channel):
+        return
+
+    conn.execute(
+        "INSERT INTO pins (channel, position) VALUES (?, ?)",
+        (channel, (conn.execute("SELECT MAX(position) FROM pins").fetchone()[0] or 0) + _SPACING),
+    )
+    conn.commit()
+
+
+def unpin(conn: sqlite3.Connection, channel: str) -> None:
+    conn.execute("DELETE FROM pins WHERE channel = ?", (channel,))
+    conn.commit()
+
+
+def toggle(conn: sqlite3.Connection, channel: str) -> bool:
+    """Pin an unpinned channel or unpin a pinned one. Returns the new state."""
+    if is_pinned(conn, channel):
+        unpin(conn, channel)
+        return False
+
+    pin(conn, channel)
+    return True
+
+
+def swap(conn: sqlite3.Connection, channel: str, other: str) -> None:
+    """Exchange the positions of two pinned channels.
+
+    The caller picks `other` from what is on screen, so a move only ever
+    reorders rows the user can see. Both must already be pinned.
+    """
+    positions = pinned_positions(conn)
+    if channel not in positions or other not in positions:
+        return
+
+    conn.executemany(
+        "UPDATE pins SET position = ? WHERE channel = ?",
+        [(positions[other], channel), (positions[channel], other)],
+    )
+    conn.commit()

--- a/src/lemonaid/inbox/tui/app.py
+++ b/src/lemonaid/inbox/tui/app.py
@@ -16,6 +16,7 @@ from rich.text import Text
 from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.coordinate import Coordinate
 from textual.timer import Timer
 from textual.widgets import DataTable, Footer, Header, Input, Static
 
@@ -43,7 +44,8 @@ from ...tmux.scratch import (
     size_has_drifted,
 )
 from ...tmux.session import spawn_session
-from .. import db, undo
+from .. import db, pins, undo
+from .help_screen import HelpScreen
 from .screens import RenameScreen, SnoozeScreen, format_wake_time
 from .table import ClickToActTable
 from .utils import (
@@ -53,7 +55,9 @@ from .utils import (
     HERE_BAR_STYLE,
     HERE_BLOCK,
     JUMP_DIGITS,
+    PIN_MARK,
     UNREAD_MARKER_STYLE,
+    backend_cell,
     jump_gutter,
     set_terminal_title,
     styled_cell,
@@ -264,7 +268,13 @@ def _as_card(
     ]
     # Right-justified so the backend labels line up against the pane's edge
     # whatever their width, rather than against each other's first character.
+    #
+    # A card has height the single-line row does not, so the pin mark moves off
+    # the label's own line onto the one below it, where it is a mark rather than
+    # a third character of the label.
     backend = cells[_BACKEND_CELL].copy()
+    if backend.plain.endswith(PIN_MARK):
+        backend = backend_cell(backend[: -len(PIN_MARK)], True, stacked=True)
     backend.justify = "right"
     return [Text("\n").join(lines), backend]
 
@@ -612,6 +622,15 @@ class LemonaidApp(App):
         for b in _build_bindings(kb.copy_resume, "copy_resume", "Copy"):
             self.bind(b.key, b.action, description=b.description, show=False)
 
+        for b in _build_bindings(kb.pin, "pin", "Pin"):
+            self.bind(b.key, b.action, description=b.description, show=b.show)
+
+        # Named keys rather than a string of alternatives: these carry a modifier.
+        if kb.move_pin_up:
+            self.bind(kb.move_pin_up, "move_pin_up", description="Move Up", show=False)
+        if kb.move_pin_down:
+            self.bind(kb.move_pin_down, "move_pin_down", description="Move Down", show=False)
+
         for b in _build_bindings(kb.tmux_resume, "tmux_resume", "Tmux"):
             self.bind(b.key, b.action, description=b.description, show=False)
 
@@ -622,7 +641,7 @@ class LemonaidApp(App):
 
         # Key hints share the bottom row with the status text, so they're a toggle
         # rather than a permanent fixture. Hidden from the footer it controls.
-        self.bind("question_mark", "toggle_keys", description="Keys", show=False)
+        self.bind("question_mark", "help", description="Keys", show=False)
 
         for b in _build_bindings(kb.flip_position, "flip_position", "Flip", show=False):
             self.bind(b.key, b.action, description=b.description, show=b.show)
@@ -973,24 +992,31 @@ class LemonaidApp(App):
         return self._focused
 
     def _active_row(
-        self, n: db.Notification, row_index: int, focused: frozenset[str] = frozenset()
+        self,
+        n: db.Notification,
+        row_index: int,
+        focused: frozenset[str] = frozenset(),
+        pinned: frozenset[str] = frozenset(),
     ) -> tuple[str, list[Text]]:
         """Build the main-table row for a session, keyed by notification id.
 
         `row_index` is the session's position in the list, which is what its jump
         digit names - so a row's number changes when the list reorders.
 
-        `focused` is the set of ttys a user is looking at, passed in rather than
-        looked up here: it costs a subprocess, and every row in one refresh shares
-        the answer.
+        `focused` is the set of ttys a user is looking at, and `pinned` the set of
+        pinned channels. Both are passed in rather than looked up here, since
+        every row in one refresh shares the answer.
         """
         is_unread = n.is_unread
         is_here = n.metadata.get("tty", "") in focused
         return str(n.id), [
             _time_cell(n.created_at, is_unread),
             Text("●", style=UNREAD_MARKER_STYLE) if is_unread else Text(""),
-            styled_cell(
-                _backend_label(n.channel, self.config.tui.backend_labels), is_unread, "backend"
+            backend_cell(
+                styled_cell(
+                    _backend_label(n.channel, self.config.tui.backend_labels), is_unread, "backend"
+                ),
+                n.channel in pinned,
             ),
             jump_gutter(row_index, is_here) + styled_cell(n.name or "", is_unread, "name"),
             styled_cell(n.metadata.get("git_branch", ""), is_unread, "branch"),
@@ -1053,12 +1079,17 @@ class LemonaidApp(App):
             else:
                 other_notifications = []
 
+            pinned = frozenset(pins.pinned_positions(conn))
+
         unread_count = sum(1 for n in current_notifications if n.is_unread)
         self.set_class(bool(unread_count), "-unread")
         focused = self._focused_ttys()
         rebuilt = _sync_rows(
             main_table,
-            [self._active_row(n, i, focused) for i, n in enumerate(current_notifications)],
+            [
+                self._active_row(n, i, focused, pinned)
+                for i, n in enumerate(current_notifications)
+            ],
             self._card_width(),
             self._card_shape(),
             GUTTER_WIDTH,
@@ -1155,6 +1186,20 @@ class LemonaidApp(App):
         if self._history_mode:
             self._set_history_mode(False)
         self._set_snoozed_mode(not self._snoozed_mode)
+
+    def action_help(self) -> None:
+        """Show the key reference.
+
+        The footer is one row and truncates in a sidebar, so the full list lives
+        in a modal that gets the whole pane. The startup peek at the footer is
+        left alone - it is a reminder that keys exist, not the reference.
+        """
+        if self._hint_timer is not None:
+            self._hint_timer.stop()
+            self._hint_timer = None
+
+        self._show_keys(False)
+        self.push_screen(HelpScreen(self.config.tui.keybindings, wide=not self._card_layout))
 
     def action_toggle_keys(self) -> None:
         # An explicit toggle outranks the startup timer, which would otherwise
@@ -1786,6 +1831,94 @@ class LemonaidApp(App):
         _log.info("archive: %s", n.channel)
         self._refresh_notifications()
         self.notify(f"{entry.description} — press {self._undo_key()} to undo")
+
+    def _row_channels(self) -> list[str]:
+        """The channel of every row on screen, in the order they are drawn.
+
+        Read from the table rather than re-queried, so a reorder acts on the
+        list the user is looking at even when the watcher has changed the
+        inbox since the last refresh.
+        """
+        table = self.query_one(self._active_table_id(), DataTable)
+        channels = []
+        with db.connect() as conn:
+            for row in range(table.row_count):
+                key, _ = table.coordinate_to_cell_key(Coordinate(row, 0))
+                notification = db.get(conn, int(key.value)) if key and key.value else None
+                if notification:
+                    channels.append(notification.channel)
+
+        return channels
+
+    def _selected_channel(self) -> str | None:
+        """The channel of the row under the cursor, in the main list only."""
+        if self._history_mode or self._snoozed_mode:
+            return None
+
+        row_key = self._get_current_row_key()
+        if not row_key:
+            return None
+
+        with db.connect() as conn:
+            notification = db.get(conn, int(row_key))
+
+        return notification.channel if notification else None
+
+    def action_pin(self) -> None:
+        """Hold the selected session at its place in the list, or release it."""
+        channel = self._selected_channel()
+        if not channel:
+            return
+
+        with db.connect() as conn:
+            now_pinned = pins.toggle(conn, channel)
+
+        _log.info("pin: %s -> %s", channel, now_pinned)
+        self._refresh_notifications()
+        self.notify(f"{'Pinned' if now_pinned else 'Unpinned'} {channel}")
+
+    def _move_pin(self, offset: int) -> None:
+        """Trade places with the nearest pinned session `offset` away on screen.
+
+        The neighbour is taken from the rendered list rather than from the pins
+        table, so a pinned session that is currently snoozed keeps its position
+        and returns between the same two rows it sat between before.
+        """
+        channel = self._selected_channel()
+        if not channel:
+            return
+
+        with db.connect() as conn:
+            if not pins.is_pinned(conn, channel):
+                return
+
+            pinned_now = pins.pinned_positions(conn)
+            on_screen = [c for c in self._row_channels() if c in pinned_now]
+            if channel not in on_screen:
+                return
+
+            neighbour = on_screen.index(channel) + offset
+            if not 0 <= neighbour < len(on_screen):
+                return
+
+            pins.swap(conn, channel, on_screen[neighbour])
+
+        self._refresh_notifications()
+        self._select_channel(channel)
+
+    def action_move_pin_up(self) -> None:
+        self._move_pin(-1)
+
+    def action_move_pin_down(self) -> None:
+        self._move_pin(1)
+
+    def _select_channel(self, channel: str) -> None:
+        """Put the cursor back on a channel after the list around it moved."""
+        table = self.query_one(self._active_table_id(), DataTable)
+        for index, c in enumerate(self._row_channels()):
+            if c == channel and index < table.row_count:
+                table.move_cursor(row=index)
+                return
 
     def action_snooze(self) -> None:
         """Snooze the selected session out of the inbox for a chosen duration."""

--- a/src/lemonaid/inbox/tui/help_screen.py
+++ b/src/lemonaid/inbox/tui/help_screen.py
@@ -1,0 +1,223 @@
+"""The key reference, as a modal.
+
+The footer holds one row, which a sidebar is too narrow to spend on a list that
+grows every time a key is added. A modal takes the whole pane instead, so the
+same reference reads the same in either layout.
+"""
+
+from collections.abc import Iterator
+
+from textual import events
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Label, Static
+
+from ...config import KeybindingsConfig
+
+# Description per keybinding field, in the order they are shown. Fields absent
+# from here are not user-facing keys and are left out.
+_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
+    (
+        "Moving around",
+        [
+            ("select", "Switch to the selected session"),
+            ("jump_unread", "Jump to the earliest unread session"),
+            ("history", "Toggle session history"),
+            ("snoozed_list", "Show snoozed sessions"),
+        ],
+    ),
+    (
+        "Acting on a session",
+        [
+            ("mark_read", "Mark as read"),
+            ("mark_unread", "Mark as unread"),
+            ("archive", "Archive - remove it from the list"),
+            ("snooze", "Snooze until a time you pick"),
+            ("rename", "Rename (clear it to go back to the auto name)"),
+            ("undo", "Undo the last inbox change"),
+        ],
+    ),
+    (
+        "Pinning",
+        [
+            ("pin", "Pin the selected session, or unpin it"),
+            ("move_pin_up", "Move a pinned session up one slot"),
+            ("move_pin_down", "Move a pinned session down one slot"),
+        ],
+    ),
+    (
+        "The pane",
+        [
+            ("flip_position", "Move the scratch pane between top and left"),
+            ("save_size", "Save the scratch pane size (follow mode)"),
+            ("refresh", "Refresh now"),
+            ("quit", "Quit"),
+        ],
+    ),
+]
+
+
+def _key_display(value: str, field: str) -> str:
+    """How a configured key reads in the reference.
+
+    Most fields hold a set of single-character alternatives; the pin-move fields
+    hold one key name, which may carry a modifier.
+    """
+    if field in ("move_pin_up", "move_pin_down"):
+        return value.replace("shift+", "Shift+").replace("ctrl+", "Ctrl+")
+
+    return " / ".join(value)
+
+
+def help_lines(kb: KeybindingsConfig) -> list[tuple[str, list[tuple[str, str]]]]:
+    """The reference as (section, [(keys, description)]), skipping unbound keys.
+
+    Built from the live configuration rather than a written-out list, so a
+    rebound or unbound key says so instead of going stale.
+    """
+    return [
+        (
+            title,
+            [
+                (_key_display(getattr(kb, field), field), description)
+                for field, description in entries
+                if getattr(kb, field, "")
+            ],
+        )
+        for title, entries in _SECTIONS
+    ]
+
+
+def _close_hint(kb: KeybindingsConfig) -> str:
+    return ", ".join([*kb.quit, "Esc", "?"][:3]) if kb.quit else "Esc or ?"
+
+
+# Only these close the reference. A sidebar's single column scrolls, so the keys
+# that reach the rest of it have to keep working. Scoped to the modal: what these
+# do in the inbox is unaffected.
+_CLOSE_KEYS = frozenset({"escape", "q", "question_mark"})
+
+
+def _section_widgets(sections: list[tuple[str, list[tuple[str, str]]]]) -> Iterator[Widget]:
+    for title, entries in sections:
+        yield Label(title, classes="section")
+        for keys, description in entries:
+            yield Static(f"[b]{keys:<12}[/b] {description}")
+
+
+def _halves(
+    sections: list[tuple[str, list[tuple[str, str]]]],
+) -> list[list[tuple[str, list[tuple[str, str]]]]]:
+    """Split into two columns of roughly equal height, keeping section order.
+
+    Measured in rendered lines rather than section count, since the sections are
+    not the same length - splitting down the middle by count left one column
+    twice the height of the other, which is the scrolling this avoids.
+    """
+    heights = [2 + len(rows) for _title, rows in sections]  # the blank line above each
+    total = sum(heights)
+    best = min(
+        range(1, len(sections)),
+        key=lambda cut: abs(sum(heights[:cut]) - (total - sum(heights[:cut]))),
+    )
+    return [sections[:best], sections[best:]]
+
+
+class HelpScreen(ModalScreen[None]):
+    """The key reference. Any key closes it."""
+
+    CSS = """
+    HelpScreen {
+        align: center middle;
+    }
+
+    HelpScreen > Vertical {
+        width: 100%;
+        max-width: 72;
+        height: auto;
+        max-height: 100%;
+        padding: 1 2;
+        background: $surface;
+        border: thick $primary;
+    }
+
+    /* A pane wider than it is tall has the room to lay the sections out side by
+       side, which is what keeps a short one from scrolling. */
+    HelpScreen.-wide > Vertical {
+        max-width: 100%;
+    }
+
+    HelpScreen.-wide .columns {
+        layout: horizontal;
+        height: auto;
+    }
+
+    HelpScreen.-wide .column {
+        width: 1fr;
+        height: auto;
+        padding-right: 2;
+    }
+
+    HelpScreen .title {
+        width: 100%;
+        text-align: center;
+        text-style: bold;
+        padding-bottom: 1;
+    }
+
+    HelpScreen .section {
+        color: $text-muted;
+        text-style: bold;
+        padding-top: 1;
+    }
+
+    HelpScreen VerticalScroll > Static {
+        padding-left: 2;
+    }
+
+    HelpScreen .hint {
+        color: $text-muted;
+        text-style: italic;
+        padding-top: 1;
+        text-align: center;
+    }
+    """
+
+    BINDINGS = [("escape", "close", "Close")]
+
+    def __init__(self, keybindings: KeybindingsConfig, wide: bool = False) -> None:
+        super().__init__()
+        self.keybindings = keybindings
+        self.wide = wide
+
+    def compose(self) -> ComposeResult:
+        sections = [(title, rows) for title, rows in help_lines(self.keybindings) if rows]
+        with Vertical():
+            yield Label("Keys", classes="title")
+            if self.wide:
+                with Horizontal(classes="columns"):
+                    for half in _halves(sections):
+                        with Vertical(classes="column"):
+                            yield from _section_widgets(half)
+            else:
+                with VerticalScroll():
+                    yield from _section_widgets(sections)
+            yield Label("q, Esc, or ? to close", classes="hint")
+
+    def on_mount(self) -> None:
+        self.set_class(self.wide, "-wide")
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key not in _CLOSE_KEYS:
+            return
+
+        # Stopped, or the key carries on to the app underneath - where escape is
+        # bound to quit, so closing the reference closed lemonaid with it.
+        event.stop()
+        event.prevent_default()
+        self.dismiss(None)
+
+    def action_close(self) -> None:
+        self.dismiss(None)

--- a/src/lemonaid/inbox/tui/utils.py
+++ b/src/lemonaid/inbox/tui/utils.py
@@ -81,6 +81,32 @@ HERE_BLOCK = "\u2588"
 HERE_BAR = "\u2503"
 HERE_BAR_STYLE = "bright_green"
 
+# Square, where the unread marker is round: the two sit near each other and say
+# different things. It shares the backend column rather than taking one of its
+# own - on its own line under the label in a card, which has the height for it,
+# and in the label's spare third cell in a single-line row, which does not.
+PIN_MARK = "\u25aa"  # ▪
+PIN_MARK_STYLE = "yellow"
+
+
+def backend_cell(label: Text, is_pinned: bool, *, stacked: bool = False) -> Text:
+    """The backend label, with the pin mark when the session is pinned.
+
+    `stacked` puts the mark on its own line under the label, which only a card
+    has the height for. A single-line row takes the label column's spare third
+    cell instead.
+
+    The mark is a span rather than the Text's own style: concatenating takes the
+    left operand's base style for the whole result, so a style set here would
+    run on under whatever follows.
+    """
+    if not is_pinned:
+        return label
+
+    cell = label + Text(f"\n{PIN_MARK}" if stacked else PIN_MARK)
+    cell.stylize(PIN_MARK_STYLE, len(label.plain), len(cell.plain))
+    return cell
+
 
 def jump_digit(row_index: int) -> str:
     """The digit that jumps to `row_index`, or "" past the tenth row."""

--- a/src/lemonaid/tmux/follow.py
+++ b/src/lemonaid/tmux/follow.py
@@ -39,7 +39,10 @@ MARKER_OPTION = "@lemonaid_scratch"  # set on the pane itself; how it is found a
 PLACEHOLDER_COMMAND = ("env", "LEMONAID_PLACEHOLDER=1", "sleep", "2147483647")
 _PLACEHOLDER_GLOB = "*LEMONAID_PLACEHOLDER*"
 
-HOOKS = ("session-window-changed", "client-session-changed")
+# client-attached because neither of the others fires on a plain `tmux attach`:
+# reattaching to the session a client already had changes no window and no
+# session, so nothing swapped the inbox in and the window kept its placeholder.
+HOOKS = ("session-window-changed", "client-session-changed", "client-attached")
 RETIRED_HOOKS = ("after-select-window",)  # fires alongside session-window-changed
 _HOOK_INDEX = 100
 _SCRATCH_SESSION = "_lma_scratch"
@@ -195,17 +198,18 @@ def hook_command() -> str:
 
 
 def orphan_hook_command() -> str:
-    """Kill a window left holding nothing but a placeholder.
+    """Kill the placeholder in a window left holding nothing else.
 
     Runs on window-pane-changed, whose context is the window whose active pane
-    changed - which is what happens when a window's last real pane exits. Never
-    a session's last window: with detach-on-destroy that would detach the client.
+    changed - which is what happens when a window's last real pane exits.
+
+    The pane goes rather than the window: a window with no panes closes on its
+    own, and a session with no windows follows, so exiting the last shell ends
+    the session the way it would without follow mode. What happens to a client
+    watching it is then `detach-on-destroy`, which is the user's to set.
     """
-    condition = (
-        f"#{{&&:#{{>:#{{session_windows}},1}},"
-        f"#{{&&:#{{==:#{{window_panes}},1}},{_is_placeholder()}}}}}"
-    )
-    return f"if-shell -F '{condition}' 'kill-window'"
+    condition = f"#{{&&:#{{==:#{{window_panes}},1}},{_is_placeholder()}}}"
+    return f"if-shell -F '{condition}' 'kill-pane'"
 
 
 def resize_hook_command() -> str:

--- a/tests/test_follow_hook.py
+++ b/tests/test_follow_hook.py
@@ -158,6 +158,32 @@ def test_a_switch_that_fires_two_hooks_joins_once(tmux):
     assert (pane, 58, 90, False) in panes
 
 
+def test_the_pane_comes_back_on_attach(tmux):
+    """Reattaching changes no window and no session, so the other two hooks are
+    silent - and the window kept the placeholder the pane had been swapped out
+    of, which renders as a blank pane until something forces the swap."""
+    pane = _followed_pane(tmux)
+    tmux("select-window", "-t", "a:w2")
+    assert (pane, 58, 90, False) in _panes(tmux, "a:w2")
+
+    tmux("detach-client", "-s", "a")
+    client = subprocess.Popen(
+        ["tmux", *tmux("display", "-p", "#{socket_path}").args[1:3], "-C", "attach", "-t", "a"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        tmux("refresh-client", "-C", "245x90")
+        assert (pane, 58, 90, False) in _panes(tmux, "a:w2")
+    finally:
+        client.kill()
+
+
+def test_attaching_is_one_of_the_hooks():
+    assert "client-attached" in follow.HOOKS
+
+
 def test_the_switch_target_keeps_focus(tmux):
     _followed_pane(tmux)
 
@@ -351,15 +377,30 @@ def test_a_window_left_holding_only_a_placeholder_is_closed(tmux):
     assert windows == ["w1"]
 
 
-def test_a_sessions_last_window_is_never_closed(tmux):
-    """detach-on-destroy would take the client with it."""
+def test_exiting_the_last_shell_ends_the_session(tmux):
+    """The placeholder must not hold a session open once its shells are gone.
+
+    Killing the pane rather than the window leaves the teardown to tmux: an
+    empty window closes, and its session follows. What that does to a client
+    watching it is `detach-on-destroy`, which is the user's setting.
+    """
     _followed_pane(tmux)
     tmux("switch-client", "-t", "b:w2")
     tmux("switch-client", "-t", "a:w1")
     tmux("kill-window", "-t", "b:w1")
     tmux("kill-pane", "-t", _main_pane(tmux, "b:w2")[0])
 
-    assert tmux("list-windows", "-t", "b", "-F", "#{window_name}").stdout.split() == ["w2"]
+    assert "b" not in tmux("list-sessions", "-F", "#{session_name}").stdout.split()
+
+
+def test_a_placeholder_alone_in_a_window_is_removed(tmux):
+    """The window then has nothing in it, so tmux closes it."""
+    _followed_pane(tmux)
+    tmux("switch-client", "-t", "b:w2")
+    tmux("switch-client", "-t", "a:w1")
+    tmux("kill-pane", "-t", _main_pane(tmux, "b:w2")[0])
+
+    assert tmux("list-windows", "-t", "b", "-F", "#{window_name}").stdout.split() == ["w1"]
 
 
 def test_the_slot_keeps_its_width_when_the_client_shrinks(tmux):

--- a/tests/test_help_screen.py
+++ b/tests/test_help_screen.py
@@ -1,0 +1,69 @@
+"""The key reference: what it lists, and that it cannot go stale."""
+
+import dataclasses
+
+from lemonaid.config import KeybindingsConfig
+from lemonaid.inbox.tui.help_screen import _SECTIONS, _halves, help_lines
+
+
+def _entries(kb: KeybindingsConfig) -> dict[str, str]:
+    return {desc: keys for _title, rows in help_lines(kb) for keys, desc in rows}
+
+
+def test_every_listed_field_exists_on_the_config():
+    """A renamed keybinding field fails here rather than vanishing from the list."""
+    fields = {f.name for f in dataclasses.fields(KeybindingsConfig)}
+
+    assert {field for _t, rows in _SECTIONS for field, _d in rows} <= fields
+
+
+def test_the_keys_shown_are_the_ones_configured():
+    kb = KeybindingsConfig(archive="X")
+
+    assert "X" in _entries(kb)["Archive - remove it from the list"]
+
+
+def test_an_unbound_key_is_left_out():
+    assert any("Quit" in desc for desc in _entries(KeybindingsConfig()))
+    assert not any("Quit" in desc for desc in _entries(KeybindingsConfig(quit="")))
+
+
+def test_alternatives_are_shown_together():
+    assert _entries(KeybindingsConfig(archive="aD"))["Archive - remove it from the list"] == "a / D"
+
+
+def test_a_modifier_key_is_spelled_out():
+    kb = KeybindingsConfig(move_pin_up="shift+up")
+
+    assert _entries(kb)["Move a pinned session up one slot"] == "Shift+up"
+
+
+def test_the_pin_keys_are_listed():
+    listed = _entries(KeybindingsConfig())
+
+    assert "Pin the selected session, or unpin it" in listed
+    assert "Move a pinned session down one slot" in listed
+
+
+def test_the_columns_are_close_to_the_same_height():
+    """Splitting by section count left one column twice the other's height."""
+    sections = [(t, r) for t, r in help_lines(KeybindingsConfig()) if r]
+    left, right = _halves(sections)
+
+    def lines(half):
+        return sum(2 + len(rows) for _title, rows in half)
+
+    assert abs(lines(left) - lines(right)) <= 3
+
+
+def test_a_split_keeps_every_section_and_their_order():
+    sections = [(t, r) for t, r in help_lines(KeybindingsConfig()) if r]
+    left, right = _halves(sections)
+
+    assert left + right == sections
+
+
+def test_both_columns_get_something():
+    left, right = _halves([(t, r) for t, r in help_lines(KeybindingsConfig()) if r])
+
+    assert left and right

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -1,0 +1,330 @@
+"""Pinned sessions: ordering, and what happens to pins nobody can see."""
+
+import asyncio
+import time
+
+from rich.text import Span, Text
+
+from lemonaid.inbox import db, pins
+from lemonaid.inbox.tui import app
+from lemonaid.inbox.tui.app import LemonaidApp
+from lemonaid.inbox.tui.utils import (
+    FIELD_STYLES,
+    PIN_MARK,
+    PIN_MARK_STYLE,
+    backend_cell,
+    styled_cell,
+)
+
+
+def _session(conn, channel: str, name: str = ""):
+    return db.register_working(
+        conn, channel=channel, message="working", name=name or channel, metadata={}
+    )
+
+
+def _order(conn) -> list[str]:
+    return [n.channel for n in db.get_active(conn)]
+
+
+def test_pinned_sessions_come_first(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "b:2", "c:3"):
+            _session(conn, channel)
+
+        pins.pin(conn, "c:3")
+
+        assert _order(conn)[0] == "c:3"
+
+
+def test_a_pinned_session_stays_put_when_it_goes_unread(tmp_path):
+    """Pinning fixes position; it does not exempt a session from being unread."""
+    with db.connect(tmp_path / "t.db") as conn:
+        _session(conn, "pinned:1")
+        _session(conn, "loud:2")
+        pins.pin(conn, "pinned:1")
+
+        db.add(conn, channel="loud:2", message="needs you", name="loud", metadata={})
+
+        assert _order(conn) == ["pinned:1", "loud:2"]
+
+
+def test_pin_order_follows_position_not_pin_time(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "b:2"):
+            _session(conn, channel)
+        pins.pin(conn, "a:1")
+        pins.pin(conn, "b:2")
+
+        pins.swap(conn, "a:1", "b:2")
+
+        assert _order(conn)[:2] == ["b:2", "a:1"]
+
+
+def test_unpinned_sessions_keep_sorting_unread_first(tmp_path):
+    """Pinning must not reach rows that have no pin.
+
+    A tiebreak between two pins sharing a position sorted every row when it was
+    placed above the status test, and unpinned rows - all NULL position, so all
+    tied - fell through to it and came out alphabetical.
+    """
+    with db.connect(tmp_path / "t.db") as conn:
+        now = time.time()
+        for channel, status, age in (
+            ("z:1", "unread", 300),
+            ("m:2", "read", 50),
+            ("a:3", "read", 200),
+        ):
+            n = _session(conn, channel)
+            conn.execute(
+                "UPDATE notifications SET status = ?, created_at = ? WHERE id = ?",
+                (status, now - age, n.id),
+            )
+        conn.commit()
+
+        assert _order(conn) == ["z:1", "m:2", "a:3"]
+
+
+def test_an_unread_below_a_pin_still_sorts_above_a_read(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        now = time.time()
+        for channel, status, age in (
+            ("pin:1", "read", 10),
+            ("read:2", "read", 50),
+            ("unread:3", "unread", 300),
+        ):
+            n = _session(conn, channel)
+            conn.execute(
+                "UPDATE notifications SET status = ?, created_at = ? WHERE id = ?",
+                (status, now - age, n.id),
+            )
+        conn.commit()
+        pins.pin(conn, "pin:1")
+
+        assert _order(conn) == ["pin:1", "unread:3", "read:2"]
+
+
+def test_toggle_reports_the_new_state(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        _session(conn, "a:1")
+
+        assert pins.toggle(conn, "a:1") is True
+        assert pins.toggle(conn, "a:1") is False
+        assert not pins.is_pinned(conn, "a:1")
+
+
+def test_pinning_twice_does_not_move_it(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "b:2"):
+            _session(conn, channel)
+        pins.pin(conn, "a:1")
+        pins.pin(conn, "b:2")
+
+        pins.pin(conn, "a:1")
+
+        assert _order(conn)[:2] == ["a:1", "b:2"]
+
+
+def test_a_pin_survives_a_new_notification(tmp_path):
+    """The reason pins live in their own table rather than on notification rows."""
+    with db.connect(tmp_path / "t.db") as conn:
+        _session(conn, "a:1")
+        _session(conn, "b:2")
+        pins.pin(conn, "b:2")
+
+        db.add(conn, channel="b:2", message="fresh", name="b", metadata={})
+
+        assert _order(conn)[0] == "b:2"
+
+
+def test_a_snoozed_pin_keeps_its_place_while_away(tmp_path):
+    """A pin nobody can see is not renumbered by a move made without it."""
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "x:2", "b:3"):
+            _session(conn, channel)
+        for channel in ("a:1", "x:2", "b:3"):
+            pins.pin(conn, channel)
+
+        away = db.get_active(conn)
+        db.snooze(conn, next(n.id for n in away if n.channel == "x:2"), time.time() + 3600)
+        assert _order(conn) == ["a:1", "b:3"]
+
+        pins.swap(conn, "b:3", "a:1")  # the move the user could make on screen
+        db.unsnooze(conn, "x:2")
+
+        assert _order(conn) == ["b:3", "x:2", "a:1"]
+
+
+def test_a_move_does_not_pull_an_absent_pin_along(tmp_path):
+    """Positions are never renumbered, so an absent pin keeps the place it held.
+
+    The absent pin is first here, which is where renumbering the visible rows
+    from zero would send it to the back of the list - a move onto a row the
+    user could not see and said nothing about.
+    """
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "b:2", "c:3"):
+            _session(conn, channel)
+            pins.pin(conn, channel)
+
+        away = db.get_active(conn)
+        db.snooze(conn, next(n.id for n in away if n.channel == "a:1"), time.time() + 3600)
+
+        pins.swap(conn, "c:3", "b:2")
+        db.unsnooze(conn, "a:1")
+
+        assert _order(conn) == ["a:1", "c:3", "b:2"]
+
+
+def test_archiving_clears_the_pin(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        _session(conn, "a:1")
+        pins.pin(conn, "a:1")
+
+        db.archive(conn, db.get_active(conn)[0].id)
+
+        assert not pins.is_pinned(conn, "a:1")
+
+
+def test_snoozing_keeps_the_pin(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        _session(conn, "a:1")
+        pins.pin(conn, "a:1")
+
+        db.snooze(conn, db.get_active(conn)[0].id, time.time() + 3600)
+
+        assert pins.is_pinned(conn, "a:1")
+
+
+def test_swap_ignores_a_channel_that_is_not_pinned(tmp_path):
+    with db.connect(tmp_path / "t.db") as conn:
+        for channel in ("a:1", "b:2"):
+            _session(conn, channel)
+        pins.pin(conn, "a:1")
+
+        pins.swap(conn, "a:1", "b:2")
+
+        assert _order(conn) == ["a:1", "b:2"]
+
+
+# --- the mark ---------------------------------------------------------------
+
+
+def test_a_pinned_row_is_marked_in_the_backend_column():
+    label = styled_cell("CC", False, "backend")
+
+    assert backend_cell(label, True).plain == f"CC{PIN_MARK}"
+    assert backend_cell(label, False).plain == "CC"
+
+
+def test_the_mark_colours_only_itself():
+    """The mark is a span over its own cell, so the label keeps its own colour."""
+    marked = backend_cell(styled_cell("CC", False, "backend"), True)
+
+    assert marked.spans == [Span(2, 3, PIN_MARK_STYLE)]
+    assert marked.style == FIELD_STYLES["backend"]
+
+
+def test_a_card_puts_the_mark_under_the_label():
+    """A card has the height to give the mark its own line; a row does not."""
+    label = styled_cell("CC", False, "backend")
+
+    assert backend_cell(label, True, stacked=True).plain == f"CC\n{PIN_MARK}"
+
+
+def test_the_stacked_mark_keeps_its_own_colour():
+    marked = backend_cell(styled_cell("CC", False, "backend"), True, stacked=True)
+
+    assert marked.spans == [Span(2, 4, PIN_MARK_STYLE)]
+
+
+def test_the_mark_fits_the_column():
+    """The backend column is three wide for a two-character label."""
+    assert len(backend_cell(styled_cell("CC", False, "backend"), True).plain) == 3
+
+
+def test_a_card_moves_an_inline_mark_onto_its_own_line():
+    """Rows carry the mark inline; the card restacks what it is handed."""
+    cells = [
+        Text("15:48:29"),
+        Text(""),
+        backend_cell(styled_cell("CC", False, "backend"), True),
+        Text("a-name"),
+        Text(""),
+        Text("~/w/x"),
+        Text("a message"),
+    ]
+    _body, backend = app._as_card(cells, 40)
+
+    assert backend.plain == f"CC\n{PIN_MARK}"
+
+
+def test_an_unpinned_card_keeps_a_bare_label():
+    cells = [
+        Text("15:48:29"),
+        Text(""),
+        styled_cell("CC", False, "backend"),
+        Text("a-name"),
+        Text(""),
+        Text("~/w/x"),
+        Text("a message"),
+    ]
+    _body, backend = app._as_card(cells, 40)
+
+    assert backend.plain == "CC"
+
+
+# --- through the TUI -------------------------------------------------------
+#
+# Only the wiring is exercised here - that the keys reach the actions and that
+# the actions read the list off the table. The ordering rules themselves are
+# covered above, against the database, where no app is involved: a watcher
+# thread from an earlier test outlives it and archives rows out of whichever
+# database is current, so a test that keeps an app alive across several frames
+# cannot rely on its rows still being there.
+
+
+def test_the_keys_are_bound(monkeypatch):
+    """`p` and the shift arrows reach their actions."""
+    called: list[str] = []
+    monkeypatch.setattr(LemonaidApp, "_archive_channel", lambda self, channel: None)
+    monkeypatch.setattr(LemonaidApp, "action_pin", lambda self: called.append("pin"))
+    monkeypatch.setattr(LemonaidApp, "action_move_pin_up", lambda self: called.append("up"))
+    monkeypatch.setattr(LemonaidApp, "action_move_pin_down", lambda self: called.append("down"))
+
+    async def run():
+        app = LemonaidApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            for key in ("p", "shift+up", "shift+down"):
+                await pilot.press(key)
+                await pilot.pause()
+
+    asyncio.run(run())
+
+    assert called == ["pin", "up", "down"]
+
+
+def test_an_unbound_move_key_is_not_registered(monkeypatch):
+    """Setting a move key to "" leaves it unbound rather than crashing."""
+    from lemonaid import config as config_mod
+    from lemonaid.inbox.tui import app as app_mod
+
+    cfg = config_mod.load_config()
+    cfg.tui.keybindings.move_pin_up = ""
+    monkeypatch.setattr(app_mod, "load_config", lambda: cfg)
+
+    called: list[str] = []
+    monkeypatch.setattr(LemonaidApp, "_archive_channel", lambda self, channel: None)
+    monkeypatch.setattr(LemonaidApp, "action_move_pin_up", lambda self: called.append("up"))
+
+    async def run():
+        app = LemonaidApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("shift+up")
+            await pilot.pause()
+
+    asyncio.run(run())
+
+    assert called == []

--- a/tests/test_status_row.py
+++ b/tests/test_status_row.py
@@ -2,17 +2,19 @@
 
 import asyncio
 
+from textual.containers import VerticalScroll
 from textual.widgets import Footer, Static
 
 from lemonaid.inbox.tui.app import LemonaidApp
+from lemonaid.inbox.tui.help_screen import HelpScreen
 
 
-def _run(steps):
+def _run(steps, size=(120, 20)):
     """Drive the app, calling `steps(app, pilot)` once it has settled."""
 
     async def run():
         app = LemonaidApp()
-        async with app.run_test(size=(120, 20)) as pilot:
+        async with app.run_test(size=size) as pilot:
             await pilot.pause()
             await pilot.pause()
             return await steps(app, pilot)
@@ -68,22 +70,89 @@ def test_status_and_footer_share_the_bottom_row():
     assert table_heights[0] == screen_height - 2, table_heights
 
 
-def test_question_mark_toggles_hints_both_ways():
+def test_question_mark_opens_the_key_reference():
+    """The footer truncates in a sidebar, so the full list is a modal."""
+
     async def steps(app, pilot):
-        app._show_keys(False)
+        await pilot.press("question_mark")
         await pilot.pause()
-        states = []
-        for _ in range(2):
-            await pilot.press("question_mark")
+        return isinstance(app.screen, HelpScreen)
+
+    assert _run(steps)
+
+
+def test_escape_closes_the_reference_and_not_the_app():
+    """Escape quits the app, so the modal has to stop the key reaching it."""
+
+    async def steps(app, pilot):
+        await pilot.press("question_mark")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        return isinstance(app.screen, HelpScreen), app.is_running
+
+    still_up, running = _run(steps)
+    assert not still_up
+    assert running
+
+
+def test_the_reference_closes_on_q_and_on_question_mark():
+    async def steps(app, pilot, key):
+        await pilot.press("question_mark")
+        await pilot.pause()
+        await pilot.press(key)
+        await pilot.pause()
+        return isinstance(app.screen, HelpScreen)
+
+    assert not _run(lambda a, p: steps(a, p, "q"))
+    assert not _run(lambda a, p: steps(a, p, "question_mark"))
+
+
+def test_an_arrow_scrolls_the_reference_rather_than_closing_it():
+    """A sidebar's column scrolls, so arrows have to reach the rest of it."""
+
+    async def steps(app, pilot):
+        await pilot.press("question_mark")
+        await pilot.pause()
+        for key in ("down", "up", "pagedown"):
+            await pilot.press(key)
             await pilot.pause()
-            states.append(app.query_one(Footer).display)
-        return states
+        return isinstance(app.screen, HelpScreen)
 
-    assert _run(steps) == [True, False]
+    assert _run(steps)
 
 
-def test_toggling_cancels_the_startup_timeout():
-    """Otherwise the timer would yank the hints away mid-read."""
+def test_an_arrow_moves_the_reference_down():
+    """Not closing is half of it; the column has to actually move."""
+
+    async def steps(app, pilot):
+        await pilot.press("question_mark")
+        await pilot.pause()
+        column = app.screen.query_one(VerticalScroll)
+        for _ in range(5):
+            await pilot.press("down")
+            await pilot.pause()
+        return column.max_scroll_y, column.scroll_offset.y
+
+    # Narrow: the scrolling column is the sidebar's layout, not the top bar's.
+    reachable, moved = _run(steps, size=(58, 20))
+    assert reachable > 0, "nothing below the fold - the test pane is too tall"
+    assert moved > 0
+
+
+def test_opening_the_reference_yields_the_footer_row_to_the_status():
+    async def steps(app, pilot):
+        await pilot.press("question_mark")
+        await pilot.pause()
+        return app.query_one(Footer).display, app.query_one("#status", Static).display
+
+    footer, status = _run(steps)
+    assert not footer
+    assert status
+
+
+def test_opening_the_reference_cancels_the_startup_timeout():
+    """Otherwise the timer would swap the row back while the modal is up."""
 
     async def steps(app, pilot):
         assert app._hint_timer is not None


### PR DESCRIPTION
🍋:

Pins a session to a fixed place in the inbox. `p` pins the selected session or releases it; `Shift`+`↑`/`↓` move a pin one slot. Both keys are configurable.

A pinned session holds its place whatever its status, so an unread pin no longer jumps to the top - which is the point of pinning it.

`?` now opens a key reference, replacing the footer's one-row hint strip.

### Where pins live

A pin belongs to a **channel**, not a notification, so it gets its own table rather than a column on `notifications`. Snooze and archive write across existing rows (`WHERE channel = ?`), but `register()` inserts a fresh row that knows nothing about prior ones - a pin stored that way would silently evaporate the next time the session spoke.

`position` is `REAL` so a later insert-between-two-rows has room. Nothing today needs it; moving a pin only ever swaps two values.

### Why positions are never renumbered

Positions are sparse and stay that way. A pinned session that is snoozed keeps its number while it is away, and the gaps in the rendered list are where the absent pins will return.

Moving a pin swaps its position with the neighbour above or below it *on screen*. The alternative - renumbering the visible rows contiguously - decides where an absent pin sits based on a list it wasn't in, so you would wake it up and find it moved. Two tests pin this: one where the absent pin sits between the swapped rows, and one where it is first, which is where renumbering flings it to the back.

Archiving clears a pin; snoozing keeps it. Snooze is "not now" and the session comes back to its place; archive is "done" and would otherwise leave a pin on a session absent from the list.

### Reordering reads the table, not the database

`_move_pin` takes the on-screen order from the rendered table rather than re-querying. The watcher can archive rows between refreshes, so a second query can return a list the user was never shown - and a reorder should act on what they are looking at.

### Keybinding config

`move_pin_up` / `move_pin_down` name one key each (`"shift+up"`), unlike the existing fields where each character is a separate alternative. `_build_bindings` splits per character and can't express a modifier. Documented in `docs/keybindings.md`.

### The pin mark

The backend column is `width=3` carrying a two-character label (`CC`, `cx`), so the mark takes the spare cell rather than a column of its own - no width cost, and no interaction with the jump digit, the here-marker, or the unread dot, which all live in the gutter.

Square (`▪`) where the unread marker is round, and yellow: colour in this table identifies which *field* you are looking at, so the mark gets its own span rather than recolouring the label.

### The key reference

The footer is one row. In a sidebar it truncated before reaching the `?` it advertised, and the key list only grows. The modal gets the whole pane and reads the same in either layout.

It is built from the live `KeybindingsConfig` rather than a written-out list, so a rebound key shows its new binding and an unbound one is left out. A test asserts every field named in the reference exists on the config, so renaming a keybinding field fails the suite instead of silently dropping a row.

`?` no longer toggles the footer; the startup peek is unchanged.

### Follow mode: the placeholder no longer holds a window open

Two bugs from one cause - the placeholder is a real pane, and it outlives the window's content.

**Exiting your last shell stopped ending the session.** The placeholder is still there once the shells are gone, so the window did not close, the session did not close, and follow mode swapped the inbox into what was left. There was already a rule removing a window holding nothing but a placeholder, but it declined to act on a session's last window - exactly this case - to avoid `detach-on-destroy` taking the client with it. It now kills the *pane*: an empty window closes on its own, a session with no windows follows, and where an attached client goes next is the user's `detach-on-destroy` setting rather than ours to decide.

**The sidebar was blank after `tmux a`.** Reattaching changes no window and no session, so neither existing hook fired and the window kept the placeholder the inbox had been swapped out of. Adds `client-attached`.

### A sort regression this PR introduced and fixes

The channel tiebreak added for two pins sharing a position sat above the status test. Every unpinned row ties on a NULL position, so all of them fell through to it and sorted alphabetically instead of unread-first. It now sits last, where it can only separate rows that are otherwise equal. Two tests cover unpinned ordering, which nothing did before.

### Tests

Ordering is tested against the database, where no app is involved. Only key wiring is tested through the TUI: a watcher thread from an earlier test outlives it and archives rows out of whichever database is current, so a test that keeps an app alive across several frames can't rely on its rows still being there. That's pre-existing and not addressed here.

Each behaviour was checked by reverting it and confirming the test fails. Three consecutive full-suite runs, 660 passing.


