### PR TITLE
Stop a placeholder holding a window open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 0.19.2 (2026-08-26)
+
+#### Fixed
+
+- **Exiting your last shell ends the session again.** The placeholder left behind held the window open, and follow mode filled it with the inbox. Follow now kills the placeholder rather than the window, so tmux tears down the window and the session itself - where an attached client goes next is `detach-on-destroy`, which is yours to set.
+
+- **The sidebar comes back on attach.** Reattaching changes no window and no session, so neither hook fired and the window kept a blank placeholder until `prefix+l`.
+
 # 0.19.1 (2026-08-26)
 
 #### Fixed

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -128,9 +128,13 @@ meant the window you were returning to was full width until the hook ran, and it
 program repainted in front of you. The first visit to a window is the only time
 its layout changes: a placeholder is split in and the scratch pane swapped into it.
 
-A window whose real panes have all exited, leaving only a placeholder, is closed -
-unless it is its session's last window, since with `detach-on-destroy` that would
-detach you. Flipping position or turning follow off removes every placeholder; the
+When a window's real panes have all exited, the placeholder left behind is killed.
+The window then has nothing in it, so tmux closes it, and a session with no windows
+follows - which means exiting your last shell ends the session as it would without
+follow mode. Where an attached client goes next is `detach-on-destroy`, which is
+yours to set: `off` switches it to another session rather than detaching it.
+
+Flipping position or turning follow off removes every placeholder; the
 saved size is re-asserted whenever a window is resized, so a font change costs the
 window's own panes columns rather than the sidebar.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.19.1"
+version = "0.19.2"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/tmux/follow.py
+++ b/src/lemonaid/tmux/follow.py
@@ -39,7 +39,10 @@ MARKER_OPTION = "@lemonaid_scratch"  # set on the pane itself; how it is found a
 PLACEHOLDER_COMMAND = ("env", "LEMONAID_PLACEHOLDER=1", "sleep", "2147483647")
 _PLACEHOLDER_GLOB = "*LEMONAID_PLACEHOLDER*"
 
-HOOKS = ("session-window-changed", "client-session-changed")
+# client-attached because neither of the others fires on a plain `tmux attach`:
+# reattaching to the session a client already had changes no window and no
+# session, so nothing swapped the inbox in and the window kept its placeholder.
+HOOKS = ("session-window-changed", "client-session-changed", "client-attached")
 RETIRED_HOOKS = ("after-select-window",)  # fires alongside session-window-changed
 _HOOK_INDEX = 100
 _SCRATCH_SESSION = "_lma_scratch"
@@ -195,17 +198,18 @@ def hook_command() -> str:
 
 
 def orphan_hook_command() -> str:
-    """Kill a window left holding nothing but a placeholder.
+    """Kill the placeholder in a window left holding nothing else.
 
     Runs on window-pane-changed, whose context is the window whose active pane
-    changed - which is what happens when a window's last real pane exits. Never
-    a session's last window: with detach-on-destroy that would detach the client.
+    changed - which is what happens when a window's last real pane exits.
+
+    The pane goes rather than the window: a window with no panes closes on its
+    own, and a session with no windows follows, so exiting the last shell ends
+    the session the way it would without follow mode. What happens to a client
+    watching it is then `detach-on-destroy`, which is the user's to set.
     """
-    condition = (
-        f"#{{&&:#{{>:#{{session_windows}},1}},"
-        f"#{{&&:#{{==:#{{window_panes}},1}},{_is_placeholder()}}}}}"
-    )
-    return f"if-shell -F '{condition}' 'kill-window'"
+    condition = f"#{{&&:#{{==:#{{window_panes}},1}},{_is_placeholder()}}}"
+    return f"if-shell -F '{condition}' 'kill-pane'"
 
 
 def resize_hook_command() -> str:

--- a/tests/test_follow_hook.py
+++ b/tests/test_follow_hook.py
@@ -158,6 +158,32 @@ def test_a_switch_that_fires_two_hooks_joins_once(tmux):
     assert (pane, 58, 90, False) in panes
 
 
+def test_the_pane_comes_back_on_attach(tmux):
+    """Reattaching changes no window and no session, so the other two hooks are
+    silent - and the window kept the placeholder the pane had been swapped out
+    of, which renders as a blank pane until something forces the swap."""
+    pane = _followed_pane(tmux)
+    tmux("select-window", "-t", "a:w2")
+    assert (pane, 58, 90, False) in _panes(tmux, "a:w2")
+
+    tmux("detach-client", "-s", "a")
+    client = subprocess.Popen(
+        ["tmux", *tmux("display", "-p", "#{socket_path}").args[1:3], "-C", "attach", "-t", "a"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        tmux("refresh-client", "-C", "245x90")
+        assert (pane, 58, 90, False) in _panes(tmux, "a:w2")
+    finally:
+        client.kill()
+
+
+def test_attaching_is_one_of_the_hooks():
+    assert "client-attached" in follow.HOOKS
+
+
 def test_the_switch_target_keeps_focus(tmux):
     _followed_pane(tmux)
 
@@ -351,15 +377,30 @@ def test_a_window_left_holding_only_a_placeholder_is_closed(tmux):
     assert windows == ["w1"]
 
 
-def test_a_sessions_last_window_is_never_closed(tmux):
-    """detach-on-destroy would take the client with it."""
+def test_exiting_the_last_shell_ends_the_session(tmux):
+    """The placeholder must not hold a session open once its shells are gone.
+
+    Killing the pane rather than the window leaves the teardown to tmux: an
+    empty window closes, and its session follows. What that does to a client
+    watching it is `detach-on-destroy`, which is the user's setting.
+    """
     _followed_pane(tmux)
     tmux("switch-client", "-t", "b:w2")
     tmux("switch-client", "-t", "a:w1")
     tmux("kill-window", "-t", "b:w1")
     tmux("kill-pane", "-t", _main_pane(tmux, "b:w2")[0])
 
-    assert tmux("list-windows", "-t", "b", "-F", "#{window_name}").stdout.split() == ["w2"]
+    assert "b" not in tmux("list-sessions", "-F", "#{session_name}").stdout.split()
+
+
+def test_a_placeholder_alone_in_a_window_is_removed(tmux):
+    """The window then has nothing in it, so tmux closes it."""
+    _followed_pane(tmux)
+    tmux("switch-client", "-t", "b:w2")
+    tmux("switch-client", "-t", "a:w1")
+    tmux("kill-pane", "-t", _main_pane(tmux, "b:w2")[0])
+
+    assert tmux("list-windows", "-t", "b", "-F", "#{window_name}").stdout.split() == ["w1"]
 
 
 def test_the_slot_keeps_its_width_when_the_client_shrinks(tmux):


### PR DESCRIPTION
🍋:

Two follow-mode bugs, both from the same thing: the placeholder is a real pane, and it outlives the window's actual content.

**Exiting your last shell no longer ends the session.** The placeholder is still there once the shells are gone, so the window does not close, the session does not close, and follow mode swaps the inbox into what is left - a fullscreen inbox where you expected the session to be gone.

There is already a rule that removes a window holding nothing but a placeholder, but it declines to act on a session's last window, which is exactly the case here. It was guarding against `detach-on-destroy` taking the client with it.

This kills the *pane* instead of the window. An empty window closes on its own, and a session with no windows follows, so teardown goes back to being tmux's. What happens to an attached client is then `detach-on-destroy` - the user's setting, not ours to decide. `off` switches the client to another session rather than detaching it.

**The sidebar is blank after `tmux a`.** Reattaching changes no window and no session, so `session-window-changed` and `client-session-changed` are both silent. Nothing swapped the inbox in, and you were looking at the placeholder it had been swapped out of - blank, because a placeholder is an empty pane. `prefix+l` fixed it by forcing the swap.

Adds `client-attached` to the hook list.

### Tests

`test_exiting_the_last_shell_ends_the_session` replaces `test_a_sessions_last_window_is_never_closed`, which asserted the behaviour being changed. Both drive a real tmux server. Verified by reverting the fix and confirming it fails.

The attach case has a real-server test too, though only the assertion on the hook list distinguishes fixed from broken there - the fixture's control-mode client reattaches cleanly enough that the placeholder case does not reproduce in it.

Checked end to end on a throwaway server: with `detach-on-destroy off`, exiting the last shell in a two-session server ends that session and leaves the other running.

630 tests passing.
