### PR TITLE
docs: say which tmux lemonaid and follow mode need

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+#### Changed
+
+- **The docs say which tmux you need.** tmux 3.0 or later for lemonaid, and 3.6 or later for follow mode. The follow hook uses the `#{!:...}` format operator, which tmux added in 3.6; on an older tmux that term expands to nothing, the hook's condition is never true, and the sidebar stays in the window it was in. Nothing in the code changed.
+
 # 0.20.0 (2026-08-26)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Features: idle/permission notifications via plugin hooks, auto-dismiss via sessi
 
 ## Terminal Setup
 
-- **`tmux`**: See [docs/tmux.md](docs/tmux.md) for pane switching, back navigation, session templates, and window colors
+- **`tmux`** (3.0 or later; follow mode needs 3.6): See [docs/tmux.md](docs/tmux.md) for pane switching, back navigation, session templates, and window colors
 - **WezTerm**: See [docs/wezterm.md](docs/wezterm.md) for workspace/pane switching setup
 
 ## Usage

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -6,6 +6,18 @@ Lemonaid integrates with tmux to switch directly to the session and pane where a
 
 Lemonaid automatically detects when notifications come from tmux and uses the tmux switch-handler. No configuration needed.
 
+### tmux version
+
+Lemonaid needs tmux 3.0 or later. It marks its scratch pane with a pane option
+and installs its hooks as array options, and both arrived in 3.0.
+
+Follow mode needs tmux 3.6 or later. The follow hook is a tmux format expression
+that runs inside the server, and it uses the `#{!:...}` operator to ask whether
+the pane is already in the window you switched to. tmux added that operator in
+3.6. On an older tmux the term expands to nothing, the hook's condition is never
+true, and the sidebar stays in the window it was in. `tmux -V` shows what you
+have.
+
 ### Add a back-navigation keybinding (optional but recommended)
 
 Add to your `~/.tmux.conf`:
@@ -104,6 +116,8 @@ followed by `prefix+l` used to do.
 ### Follow mode
 
 Follow mode keeps the scratch pane visible across window and session switches — it follows you everywhere, giving a persistent bird's-eye view of your lemon sessions.
+
+It needs tmux 3.6 or later; see [tmux version](#tmux-version).
 
 #### Enabling follow
 
@@ -456,6 +470,12 @@ lived in it.
 1. Make sure you're running inside tmux (`echo $TMUX` should show something)
 2. Check that the notification has TTY metadata: `lemonaid inbox list --json | jq`
 3. Test manually: `tmux switch-client -t %5` (replace %5 with actual pane ID)
+
+### The sidebar stays behind when you switch windows
+
+Check your tmux version with `tmux -V`. Follow mode needs 3.6 or later; on an
+older tmux the hook runs but its condition is never true, so nothing joins the
+pane into the new window. See [tmux version](#tmux-version).
 
 ### Back navigation goes to wrong location
 


### PR DESCRIPTION
🍋:
Docs only. Nothing in the code changes.

The repo did not say which tmux it needs. I hit this on tmux 3.5a: with follow mode on, the sidebar stayed in the window it was in when I switched windows.

The cause is in the follow hook. `hook_condition()` and `_came_from()` in `src/lemonaid/tmux/follow.py` use the `#{!:...}` format operator, which tmux added in 3.6 (from tmux's CHANGES, "CHANGES FROM 3.5a TO 3.6": "add ! and !! for not and not-not"). On an older tmux that term expands to an empty string, so the hook's condition is never true and nothing joins the pane into the new window. Everything else the tmux integration uses is older: pane options and array hooks are from 3.0, `run-shell -C` and format arithmetic from 3.2.

This PR:

- adds a "tmux version" subsection to `docs/tmux.md` under Setup, stating 3.0 as the floor for lemonaid and 3.6 for follow mode, with the reason
- points to it from the Follow mode section
- adds a Troubleshooting entry for the symptom
- names the versions on the tmux bullet in the README
- adds a CHANGES.md entry under an "Unreleased" heading, with no version bump, since that felt like yours to do at release time. Happy to drop the entry or fold it into whatever you prefer.
