### PR TITLE
Write hook installs through a settings.json symlink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 0.20.1 (2026-09-11)
+
+#### Fixed
+
+- **`lemonaid claude hooks` no longer replaces a symlinked `settings.json` with a plain file.** The settings file is written whole through a temp file and a rename, and a rename onto a symlink replaces the link itself. A `~/.claude/settings.json` that pointed into a dotfiles repo became a copy, and the dotfile it pointed at never got the hook. The write now follows the link and lands in the target, for `--uninstall` as well.
+
 # 0.20.0 (2026-08-26)
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemonaid"
-version = "0.20.0"
+version = "0.20.1"
 description = "Attention inbox for managing notifications from lemons and other background tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/lemonaid/claude/install_hooks.py
+++ b/src/lemonaid/claude/install_hooks.py
@@ -52,6 +52,19 @@ def _with_hook(settings: dict, event: str, command: str) -> tuple[dict, bool]:
     return settings, True
 
 
+def _write(path: Path, settings: dict) -> None:
+    """Replace the settings file whole: a partial write is a file Claude Code will not start with.
+
+    The file is commonly a symlink into a dotfiles repo. Replacing the link itself would
+    leave a plain file in its place and the dotfile behind, so the write goes to the target.
+    """
+    target = path.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(".json.lemonaid-tmp")
+    tmp.write_text(json.dumps(settings, indent=2) + "\n")
+    tmp.replace(target)
+
+
 def install_session_start(path: Path | None = None, dry_run: bool = False) -> str:
     """Add the SessionStart hook. Returns the line to print."""
     path = path or settings_path()
@@ -64,12 +77,7 @@ def install_session_start(path: Path | None = None, dry_run: bool = False) -> st
     if dry_run:
         return f"would add SessionStart -> {_SESSION_START_COMMAND} in {path}"
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # Written whole rather than in place: a partial write here is a settings
-    # file Claude Code will not start with.
-    tmp = path.with_suffix(".json.lemonaid-tmp")
-    tmp.write_text(json.dumps(settings, indent=2) + "\n")
-    tmp.replace(path)
+    _write(path, settings)
     return f"installed SessionStart -> {_SESSION_START_COMMAND} in {path}"
 
 
@@ -88,7 +96,5 @@ def uninstall_session_start(path: Path | None = None) -> str:
     else:
         del settings["hooks"]["SessionStart"]
 
-    tmp = path.with_suffix(".json.lemonaid-tmp")
-    tmp.write_text(json.dumps(settings, indent=2) + "\n")
-    tmp.replace(path)
+    _write(path, settings)
     return f"removed SessionStart hook from {path}"

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -96,3 +96,33 @@ def test_broken_json_is_not_overwritten(tmp_path):
         install_hooks.install_session_start(p)
 
     assert p.read_text() == "{not json"
+
+
+def test_a_symlinked_settings_file_stays_a_symlink(tmp_path):
+    """The file is usually a link into a dotfiles repo; the write must land in the repo."""
+    real = tmp_path / "dotfiles" / "settings.json"
+    real.parent.mkdir()
+    real.write_text(json.dumps({"model": "opus"}))
+    link = tmp_path / "settings.json"
+    link.symlink_to(real)
+
+    install_hooks.install_session_start(link)
+
+    assert link.is_symlink()
+    assert json.loads(real.read_text())["hooks"]["SessionStart"][0]["hooks"][0]["command"] == (
+        "lemonaid claude session-start"
+    )
+
+
+def test_uninstall_also_writes_through_the_symlink(tmp_path):
+    real = tmp_path / "dotfiles" / "settings.json"
+    real.parent.mkdir()
+    real.write_text(json.dumps({}))
+    link = tmp_path / "settings.json"
+    link.symlink_to(real)
+    install_hooks.install_session_start(link)
+
+    install_hooks.uninstall_session_start(link)
+
+    assert link.is_symlink()
+    assert "SessionStart" not in json.loads(real.read_text()).get("hooks", {})


### PR DESCRIPTION
🍋:

`lemonaid claude hooks` writes `settings.json` whole - a temp file, then a rename onto the path - so a partial write can never leave Claude Code a file it will not start with. A rename onto a symlink replaces the link itself, though. My `~/.claude/settings.json` is a link into a dotfiles repo; after installing the hook it was a plain file, and the dotfile it had pointed at never got the hook.

The write now resolves the path first, so the temp file and the rename both land on the target. `--uninstall` shares the same write and had the same fault.

Two tests cover install and uninstall through a symlink. Version bumped to 0.20.1 and CHANGES.md updated.

The four `test_follow_hook.py` failures in the full suite are present on `main` for me as well, so I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
